### PR TITLE
Fix missing declaration files for `plugin.js` and `register.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cypress-xray-plugin",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "A Cypress plugin for uploading test results to Jira Xray",
     "main": "src/client.js",
     "types": "src/client.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
         "screenshot"
     ],
     "files": [
-        "src/**/*",
-        "plugin.js",
-        "register.js"
+        "src",
+        "*.js",
+        "*.ts"
     ],
     "directories": {
         "lib": "src"

--- a/publish.sh
+++ b/publish.sh
@@ -1,9 +1,0 @@
-# Remove existing directory to not publish outdated stuff.
-npx shx rm -r dist/
-# Compile Typescript code to vanilla JavaScript + type declarations.
-npm run build
-# Prepare package inside the build directory.
-npx shx cp package.json README.md LICENSE.md dist/
-# Publish from inside the build directory.
-cd dist/
-npm publish


### PR DESCRIPTION
This PR adds all `*.js` and `*.ts` files to the packaged plugin, so that these types of warnings disappear:
```ts
Could not find a declaration file for module 'cypress-xray-plugin/plugin.js'. 'node_modules/cypress-xray-plugin/plugin.js' implicitly has an 'any' type.
  If the 'cypress-xray-plugin' package actually exposes this module, try adding a new declaration (.d.ts) file containing `declare module 'cypress-xray-plugin/plugin.js';`
```