### PR TITLE
Fix default execution import behaviour for tests without test issue keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cypress-xray-plugin",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "cypress-xray-plugin",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "license": "MIT",
             "dependencies": {
                 "@cucumber/gherkin": "^26.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cypress-xray-plugin",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "description": "A Cypress plugin for uploading test results to Xray (test management for Jira)",
     "main": "plugin.js",
     "types": "plugin.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const ENV_JIRA_TEST_EXECUTION_ISSUE_KEY =
     "JIRA_TEST_EXECUTION_ISSUE_KEY";
 export const ENV_JIRA_TEST_PLAN_ISSUE_KEY = "JIRA_TEST_PLAN_ISSUE_KEY";
 export const ENV_JIRA_ATTACH_VIDEOS = "JIRA_ATTACH_VIDEOS";
+export const ENV_JIRA_CREATE_TEST_ISSUES = "JIRA_CREATE_TEST_ISSUES";
 // ================================= //
 // | Xray Configuration            | //
 // ================================= //

--- a/src/context.ts
+++ b/src/context.ts
@@ -27,6 +27,7 @@ export function initContext(config: Options) {
 const DEFAULT_OPTIONS_JIRA: JiraOptions = {
     projectKey: null,
     attachVideos: false,
+    createTestIssues: true,
 };
 const DEFAULT_OPTIONS_PLUGIN: PluginOptions = {
     overwriteIssueSummary: false,
@@ -43,7 +44,7 @@ const DEFAULT_OPTIONS_Xray: XrayOptions = {
 };
 
 const DEFAULT_OPTIONS_CUCUMBER: CucumberOptions = {
-    featureFileExtension: ".feature",
+    featureFileExtension: null,
     uploadFeatures: false,
     downloadFeatures: false,
 };

--- a/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
@@ -42,12 +42,13 @@ export abstract class ImportExecutionResultsConverter<
                 const testResult = testResults[testResults.length - 1];
                 try {
                     const issueKey = this.getTestIssueKey(testResult);
-                    if (issueKey === null) {
-                        if (!CONTEXT.config.jira.createTestIssues) {
-                            throw new Error(
-                                "No test issue key found in test title"
-                            );
-                        }
+                    if (
+                        issueKey === null &&
+                        !CONTEXT.config.jira.createTestIssues
+                    ) {
+                        throw new Error(
+                            "No test issue key found in test title"
+                        );
                     }
                     const attempts = attemptsByTitle.get(title);
                     // TODO: Support multiple iterations.

--- a/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
@@ -33,18 +33,30 @@ export abstract class ImportExecutionResultsConverter<
             testExecutionKey: CONTEXT.config.jira.testExecutionIssueKey,
         };
         json.info = this.getTestExecutionInfo(results);
-        const testsByIssueKey = this.mapTestsToIssueKeys(results);
-        const attemptsByIssueKey = this.mapAttemptsToIssueKeys(testsByIssueKey);
-        testsByIssueKey.forEach(
-            (tests: CypressCommandLine.TestResult[], key: string) => {
+        const testsByTitle = this.mapTestsToTitles(results);
+        const attemptsByTitle = this.mapAttemptsToTitles(testsByTitle);
+        testsByTitle.forEach(
+            (testResults: CypressCommandLine.TestResult[], title: string) => {
                 let test: XrayTestType;
-                const attempts = attemptsByIssueKey.get(key);
+                // TODO: Support multiple iterations.
+                const testResult = testResults[testResults.length - 1];
                 try {
-                    test = this.getTest(attempts[attempts.length - 1], key);
+                    const issueKey = this.getTestIssueKey(testResult);
+                    if (issueKey === null) {
+                        if (!CONTEXT.config.jira.createTestIssues) {
+                            throw new Error(
+                                "No test issue key found in test title"
+                            );
+                        }
+                    }
+                    const attempts = attemptsByTitle.get(title);
+                    // TODO: Support multiple iterations.
+                    test = this.getTest(attempts[attempts.length - 1]);
+                    if (issueKey !== null) {
+                        test.testKey = issueKey;
+                    }
                     if (CONTEXT.config.plugin.overwriteIssueSummary) {
-                        test.testInfo = this.getTestInfo(
-                            tests[tests.length - 1]
-                        );
+                        test.testInfo = this.getTestInfo(testResult);
                     }
                     if (!json.tests) {
                         json.tests = [test];
@@ -57,7 +69,7 @@ export abstract class ImportExecutionResultsConverter<
                         reason = error.message;
                     }
                     logWarning(
-                        `${reason}. Skipping result upload for test ${key}.`
+                        `${reason}. Skipping result upload for test "${title}".`
                     );
                 }
             }
@@ -69,12 +81,10 @@ export abstract class ImportExecutionResultsConverter<
      * Builds a test entity for an executed test.
      *
      * @param testResult the Cypress test result
-     * @param testIssueKey the test's Jira issue key
      * @return the test entity
      */
     protected abstract getTest(
-        attempt: CypressCommandLine.AttemptResult,
-        testIssueKey: string
+        attempt: CypressCommandLine.AttemptResult
     ): XrayTestType;
 
     /**
@@ -192,56 +202,38 @@ export abstract class ImportExecutionResultsConverter<
         }
     }
 
-    private mapTestsToIssueKeys(
+    private mapTestsToTitles(
         results: CypressCommandLine.CypressRunResult
     ): Map<string, CypressCommandLine.TestResult[]> {
         const map = new Map<string, CypressCommandLine.TestResult[]>();
         results.runs.forEach((run: CypressCommandLine.RunResult) => {
-            run.tests.forEach((result: CypressCommandLine.TestResult) => {
-                try {
-                    const testIssueKey = this.getTestIssueKey(result);
-                    if (!testIssueKey) {
-                        const title = result.title.join(" ");
-                        throw new Error(
-                            `No test issue key found for test "${title}"`
-                        );
-                    }
-                    if (!map.has(testIssueKey)) {
-                        map.set(testIssueKey, [result]);
-                    } else {
-                        map.get(testIssueKey).push(result);
-                    }
-                } catch (error: unknown) {
-                    let reason = error;
-                    if (error instanceof Error) {
-                        reason = error.message;
-                    }
-                    logWarning(
-                        `${reason}. Skipping result upload for this test.`
-                    );
+            run.tests.forEach((test: CypressCommandLine.TestResult) => {
+                const title = test.title.join(" ");
+                if (map.has(title)) {
+                    map.get(title).push(test);
+                } else {
+                    map.set(title, [test]);
                 }
             });
         });
         return map;
     }
 
-    private mapAttemptsToIssueKeys(
-        resultsByIssueKey: Map<string, CypressCommandLine.TestResult[]>
+    private mapAttemptsToTitles(
+        testsByTitle: Map<string, CypressCommandLine.TestResult[]>
     ): Map<string, CypressCommandLine.AttemptResult[]> {
         const map = new Map<string, CypressCommandLine.AttemptResult[]>();
-        resultsByIssueKey.forEach(
-            (value: CypressCommandLine.TestResult[], key: string) => {
-                value.forEach((result: CypressCommandLine.TestResult) => {
-                    result.attempts.forEach(
-                        (attempt: CypressCommandLine.AttemptResult) => {
-                            if (!map.has(key)) {
-                                map.set(key, [attempt]);
-                            } else {
-                                map.get(key).push(attempt);
-                            }
-                        }
-                    );
-                });
+        testsByTitle.forEach(
+            (testResults: CypressCommandLine.TestResult[], title: string) => {
+                const attempts = testResults.flatMap(
+                    (testResult: CypressCommandLine.TestResult) =>
+                        testResult.attempts
+                );
+                if (map.has(title)) {
+                    map.set(title, map.get(title).concat(attempts));
+                } else {
+                    map.set(title, attempts);
+                }
             }
         );
         return map;

--- a/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -18,11 +18,9 @@ export class ImportExecutionResultsConverterCloud extends ImportExecutionResults
     XrayTestInfoCloud
 > {
     protected getTest(
-        attempt: CypressCommandLine.AttemptResult,
-        testIssueKey: string
+        attempt: CypressCommandLine.AttemptResult
     ): XrayTestCloud {
         const json: XrayTestCloud = {
-            testKey: testIssueKey,
             start: this.truncateISOTime(
                 this.getAttemptStartDate(attempt).toISOString()
             ),

--- a/src/conversion/importExecutionResults/importExecutionResultsConverterServer.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterServer.ts
@@ -18,11 +18,9 @@ export class ImportExecutionResultsConverterServer extends ImportExecutionResult
     XrayTestInfoServer
 > {
     protected getTest(
-        attempt: CypressCommandLine.AttemptResult,
-        testIssueKey: string
+        attempt: CypressCommandLine.AttemptResult
     ): XrayTestServer {
         const json: XrayTestServer = {
-            testKey: testIssueKey,
             start: this.truncateISOTime(
                 this.getAttemptStartDate(attempt).toISOString()
             ),

--- a/src/types/xray/plugin.ts
+++ b/src/types/xray/plugin.ts
@@ -13,6 +13,7 @@ export interface Options {
 export interface JiraOptions {
     /**
      * The Jira project key.
+     *
      * @example "CYP"
      */
     projectKey: string;
@@ -45,6 +46,11 @@ export interface JiraOptions {
      * attached to the test execution issue on results upload.
      */
     attachVideos?: boolean;
+    /**
+     * Whether the plugin should create test issues for Cypress tests that
+     * have not been mapped to existing test issues.
+     */
+    createTestIssues?: boolean;
 }
 
 export interface XrayOptions {
@@ -76,7 +82,6 @@ export interface XrayOptions {
      * The test type of the test issues. This option will be used to set the
      * corresponding field on issues created during upload (happens when a test
      * does not yet have a corresponding Xray issue).
-     * issue
      *
      * @example "Manual"
      */

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -12,6 +12,7 @@ import {
     ENV_CUCUMBER_UPLOAD_FEATURES,
     ENV_JIRA_API_TOKEN,
     ENV_JIRA_ATTACH_VIDEOS,
+    ENV_JIRA_CREATE_TEST_ISSUES,
     ENV_JIRA_PASSWORD,
     ENV_JIRA_PROJECT_KEY,
     ENV_JIRA_TEST_EXECUTION_ISSUE_KEY,
@@ -53,6 +54,11 @@ export function parseEnvironmentVariables(env: Cypress.ObjectLike): void {
     if (ENV_JIRA_ATTACH_VIDEOS in env) {
         CONTEXT.config.jira.attachVideos = parseBoolean(
             env[ENV_JIRA_ATTACH_VIDEOS]
+        );
+    }
+    if (ENV_JIRA_CREATE_TEST_ISSUES in env) {
+        CONTEXT.config.jira.createTestIssues = parseBoolean(
+            env[ENV_JIRA_CREATE_TEST_ISSUES]
         );
     }
     // Xray.

--- a/test/resources/runResult.json
+++ b/test/resources/runResult.json
@@ -51,7 +51,7 @@
                 {
                     "title": [
                         "xray upload demo",
-                        "should look for paragraph elements CYP-123"
+                        "should look for paragraph elements"
                     ],
                     "state": "passed",
                     "body": "function () {\r\n        cy.get(\"p\").should(\"exist\");\r\n    }",
@@ -70,7 +70,7 @@
                 {
                     "title": [
                         "xray upload demo",
-                        "should look for the anchor element CYP-456"
+                        "should look for the anchor element"
                     ],
                     "state": "passed",
                     "body": "function () {\r\n        cy.get(\"a\").should(\"exist\");\r\n    }",
@@ -87,7 +87,7 @@
                     ]
                 },
                 {
-                    "title": ["xray upload demo", "should fail CYP-789"],
+                    "title": ["xray upload demo", "should fail"],
                     "state": "failed",
                     "body": "function () {\r\n        cy.get(\"span\").should(\"exist\");\r\n    }",
                     "displayError": "AssertionError: Timed out retrying after 4000ms: Expected to find element: `span`, but never found it.\n    at Context.eval (webpack:///./cypress/e2e/demo/example.cy.ts:15:23)",

--- a/test/src/client/xray/xrayClientCloud.ts
+++ b/test/src/client/xray/xrayClientCloud.ts
@@ -4,7 +4,7 @@ import { expect } from "chai";
 import { readFileSync } from "fs";
 import { JWTCredentials } from "../../../../src/authentication/credentials";
 import { XrayClientCloud } from "../../../../src/client/xray/xrayClientCloud";
-import { initContext } from "../../../../src/context";
+import { CONTEXT, initContext } from "../../../../src/context";
 describe("the Xray cloud client", () => {
     let details: CypressCommandLine.CypressRunResult;
     let client: XrayClientCloud;
@@ -34,6 +34,7 @@ describe("the Xray cloud client", () => {
                     (test.title = ["nothing", i.toString(), j.toString()])
             )
         );
+        CONTEXT.config.jira.createTestIssues = false;
         const result = await client.importTestExecutionResults(details);
         expect(result).to.be.null;
     });

--- a/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -37,6 +37,17 @@ describe("the conversion function", () => {
         expect(json.tests).to.have.length(3);
     });
 
+    it("should be able to convert test results into Xray JSON without creating test issues", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync("./test/resources/runResult.json", "utf-8")
+        );
+        CONTEXT.config.jira.createTestIssues = false;
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+
+        expect(json.tests).to.be.undefined;
+    });
+
     it("should be able to erase milliseconds from timestamps", () => {
         let result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResult.json", "utf-8")


### PR DESCRIPTION
This PR reverts changes made in `3.0.0` which prevented the plugin from creating new test issues in Jira. The default behaviour will again be to let the plugin create test issues for tests which haven't been mapped to existing test issues.

An option `jira.createTestIssues` has been added to enable or disable this behavious as needed.