### PR TITLE
Add step update configurability

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "source.fixAll": true,
         "source.organizeImports": true
     },
+    "editor.rulers": [80],
     "files.trimFinalNewlines": true,
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,8 @@ export const ENV_XRAY_UPLOAD_SCREENSHOTS = "XRAY_UPLOAD_SCREENSHOTS";
 export const ENV_XRAY_STATUS_PASSED = "XRAY_STATUS_PASSED";
 export const ENV_XRAY_STATUS_FAILED = "XRAY_STATUS_FAILED";
 export const ENV_XRAY_TEST_TYPE = "XRAY_TEST_TYPE";
+export const ENV_XRAY_STEPS_UPDATE = "XRAY_STEPS_UPDATE";
+export const ENV_XRAY_STEPS_MAX_LENGTH_ACTION = "XRAY_STEPS_MAX_LENGTH_ACTION";
 // ================================= //
 // | Cucumber Configuration        | //
 // ================================= //

--- a/src/context.ts
+++ b/src/context.ts
@@ -41,6 +41,10 @@ const DEFAULT_OPTIONS_Xray: XrayOptions = {
     statusPassed: "PASSED",
     statusFailed: "FAILED",
     testType: "Manual",
+    steps: {
+        update: true,
+        maxLengthAction: 8000,
+    },
 };
 
 const DEFAULT_OPTIONS_CUCUMBER: CucumberOptions = {

--- a/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
@@ -203,6 +203,25 @@ export abstract class ImportExecutionResultsConverter<
         }
     }
 
+    /**
+     * Returns a step action description truncated to the maximum length Xray
+     * allows.
+     *
+     * @param action the step's action description
+     * @returns the truncated or unmodified description if it's short enough
+     */
+    protected truncateStepAction(action: string): string {
+        if (action.length <= CONTEXT.config.xray.steps.maxLengthAction) {
+            return action;
+        }
+        // Subtract 3 for the dots.
+        const truncated = action.substring(
+            0,
+            CONTEXT.config.xray.steps.maxLengthAction - 3
+        );
+        return `${truncated}...`;
+    }
+
     private mapTestsToTitles(
         results: CypressCommandLine.CypressRunResult
     ): Map<string, CypressCommandLine.TestResult[]> {

--- a/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -66,11 +66,16 @@ export class ImportExecutionResultsConverterCloud extends ImportExecutionResults
     protected getTestInfo(
         testResult: CypressCommandLine.TestResult
     ): XrayTestInfoCloud {
-        return {
+        const testInfo: XrayTestInfoCloud = {
             projectKey: CONTEXT.config.jira.projectKey,
             summary: testResult.title.join(" "),
             type: CONTEXT.config.xray.testType,
-            steps: [{ action: testResult.body }],
         };
+        if (CONTEXT.config.xray.steps.update) {
+            testInfo.steps = [
+                { action: this.truncateStepAction(testResult.body) },
+            ];
+        }
+        return testInfo;
     }
 }

--- a/src/conversion/importExecutionResults/importExecutionResultsConverterServer.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterServer.ts
@@ -66,10 +66,16 @@ export class ImportExecutionResultsConverterServer extends ImportExecutionResult
     protected getTestInfo(
         testResult: CypressCommandLine.TestResult
     ): XrayTestInfoServer {
-        return {
+        const testInfo: XrayTestInfoServer = {
             projectKey: CONTEXT.config.jira.projectKey,
             summary: testResult.title.join(" "),
             testType: CONTEXT.config.xray.testType,
         };
+        if (CONTEXT.config.xray.steps.update) {
+            testInfo.steps = [
+                { action: this.truncateStepAction(testResult.body) },
+            ];
+        }
+        return testInfo;
     }
 }

--- a/src/types/xray/plugin.ts
+++ b/src/types/xray/plugin.ts
@@ -53,6 +53,24 @@ export interface JiraOptions {
     createTestIssues?: boolean;
 }
 
+export interface XrayStepOptions {
+    /**
+     * Whether to update a manual test issue's test steps during execution
+     * results upload. If set to true, **all** existing steps will be replaced
+     * with the plugin's steps.
+     *
+     * Note: the plugin currently creates only one step containing the code of
+     * the corresponding Cypress test function.
+     */
+    update?: boolean;
+    /**
+     * The maximum length a step's action description can have in terms of
+     * characters. Some Xray instances might enforce limits on the length and
+     * reject step updates in case the action's description exceeds said limit.
+     */
+    maxLengthAction?: number;
+}
+
 export interface XrayOptions {
     /**
      * Turns execution results upload on or off. Useful when switching upload
@@ -86,6 +104,10 @@ export interface XrayOptions {
      * @example "Manual"
      */
     testType?: string;
+    /**
+     * All options related to manual test issue steps.
+     */
+    steps?: XrayStepOptions;
 }
 
 export interface CucumberOptions {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -28,6 +28,8 @@ import {
     ENV_XRAY_CLIENT_SECRET,
     ENV_XRAY_STATUS_FAILED,
     ENV_XRAY_STATUS_PASSED,
+    ENV_XRAY_STEPS_MAX_LENGTH_ACTION,
+    ENV_XRAY_STEPS_UPDATE,
     ENV_XRAY_UPLOAD_RESULTS,
     ENV_XRAY_UPLOAD_SCREENSHOTS,
 } from "../constants";
@@ -77,6 +79,16 @@ export function parseEnvironmentVariables(env: Cypress.ObjectLike): void {
     }
     if (ENV_XRAY_STATUS_FAILED in env) {
         CONTEXT.config.xray.statusFailed = env[ENV_XRAY_STATUS_FAILED];
+    }
+    if (ENV_XRAY_STEPS_UPDATE in env) {
+        CONTEXT.config.xray.steps.update = parseBoolean(
+            env[ENV_XRAY_STEPS_UPDATE]
+        );
+    }
+    if (ENV_XRAY_STEPS_MAX_LENGTH_ACTION in env) {
+        CONTEXT.config.xray.steps.maxLengthAction = Number.parseInt(
+            env[ENV_XRAY_STEPS_MAX_LENGTH_ACTION]
+        );
     }
     // Cucumber.
     if (ENV_CUCUMBER_FEATURE_FILE_EXTENSION in env) {

--- a/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -187,4 +187,73 @@ describe("the conversion function", () => {
         expect(json.tests[1].evidence).to.be.undefined;
         expect(json.tests[2].evidence).to.be.undefined;
     });
+
+    it("should skip step updates if disabled", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync("./test/resources/runResult.json", "utf-8")
+        );
+        expectToExist(CONTEXT.config.xray);
+        CONTEXT.config.xray.steps = {
+            update: false,
+        };
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+        expectToExist(json.tests);
+        expect(json.tests).to.have.length(3);
+        expectToExist(json.tests[0].testInfo);
+        expect(json.tests[0].testInfo.steps).to.be.undefined;
+        expectToExist(json.tests[1].testInfo);
+        expect(json.tests[1].testInfo.steps).to.be.undefined;
+        expectToExist(json.tests[2].testInfo);
+        expect(json.tests[2].testInfo.steps).to.be.undefined;
+    });
+
+    it("should include step updates if enabled", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync("./test/resources/runResult.json", "utf-8")
+        );
+        expectToExist(CONTEXT.config.xray);
+        CONTEXT.config.xray.steps = {
+            update: true,
+        };
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+        expectToExist(json.tests);
+        expect(json.tests).to.have.length(3);
+        expectToExist(json.tests[0].testInfo);
+        expectToExist(json.tests[0].testInfo.steps);
+        expect(json.tests[0].testInfo.steps).to.have.length(1);
+        expect(json.tests[0].testInfo.steps[0].action).to.be.a("string");
+        expectToExist(json.tests[1].testInfo);
+        expectToExist(json.tests[1].testInfo.steps);
+        expect(json.tests[1].testInfo.steps).to.have.length(1);
+        expect(json.tests[1].testInfo.steps[0].action).to.be.a("string");
+        expectToExist(json.tests[2].testInfo);
+        expectToExist(json.tests[2].testInfo.steps);
+        expect(json.tests[2].testInfo.steps).to.have.length(1);
+        expect(json.tests[2].testInfo.steps[0].action).to.be.a("string");
+    });
+
+    it("should truncate step actions if enabled", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync("./test/resources/runResult.json", "utf-8")
+        );
+        expectToExist(CONTEXT.config.xray);
+        CONTEXT.config.xray.steps = {
+            update: true,
+            maxLengthAction: 5,
+        };
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+        expectToExist(json.tests);
+        expectToExist(json.tests[0].testInfo);
+        expectToExist(json.tests[0].testInfo.steps);
+        expect(json.tests[0].testInfo.steps[0].action.length).to.eq(5);
+        expectToExist(json.tests[1].testInfo);
+        expectToExist(json.tests[1].testInfo.steps);
+        expect(json.tests[1].testInfo.steps[0].action.length).to.eq(5);
+        expectToExist(json.tests[2].testInfo);
+        expectToExist(json.tests[2].testInfo.steps);
+        expect(json.tests[2].testInfo.steps[0].action.length).to.eq(5);
+    });
 });

--- a/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -196,6 +196,9 @@ describe("the conversion function", () => {
         CONTEXT.config.xray.steps = {
             update: false,
         };
+        // TODO: remove once #47 is fixed.
+        expectToExist(CONTEXT.config.plugin);
+        CONTEXT.config.plugin.overwriteIssueSummary = true;
         const json: XrayTestExecutionResultsCloud =
             converter.convertExecutionResults(result);
         expectToExist(json.tests);
@@ -216,6 +219,9 @@ describe("the conversion function", () => {
         CONTEXT.config.xray.steps = {
             update: true,
         };
+        // TODO: remove once #47 is fixed.
+        expectToExist(CONTEXT.config.plugin);
+        CONTEXT.config.plugin.overwriteIssueSummary = true;
         const json: XrayTestExecutionResultsCloud =
             converter.convertExecutionResults(result);
         expectToExist(json.tests);
@@ -243,6 +249,9 @@ describe("the conversion function", () => {
             update: true,
             maxLengthAction: 5,
         };
+        // TODO: remove once #47 is fixed.
+        expectToExist(CONTEXT.config.plugin);
+        CONTEXT.config.plugin.overwriteIssueSummary = true;
         const json: XrayTestExecutionResultsCloud =
             converter.convertExecutionResults(result);
         expectToExist(json.tests);

--- a/test/src/hooks.ts
+++ b/test/src/hooks.ts
@@ -107,6 +107,26 @@ describe("the before run hook", () => {
         );
     });
 
+    it("should not allow step lengths of length zero", async () => {
+        expectToExist(CONTEXT.config.xray);
+        CONTEXT.config.xray.steps = {
+            maxLengthAction: 0,
+        };
+        await expect(beforeRunHook(details)).to.eventually.be.rejectedWith(
+            "Xray plugin misconfiguration: max length of step actions must be a positive number: 0"
+        );
+    });
+
+    it("should not allow negative step action lengths", async () => {
+        expectToExist(CONTEXT.config.xray);
+        CONTEXT.config.xray.steps = {
+            maxLengthAction: -5,
+        };
+        await expect(beforeRunHook(details)).to.eventually.be.rejectedWith(
+            "Xray plugin misconfiguration: max length of step actions must be a positive number: -5"
+        );
+    });
+
     describe("the Jira client instantiation", () => {
         beforeEach(() => {
             expectToExist(details.config.env);


### PR DESCRIPTION
This PR adds addresses issue #50 by truncating very long function bodies in a test's step information. The maximum allowed length can be configured using (for example):
- `xray.steps.maxLengthAction: 1024`
- `XRAY_STEPS_MAX_LENGTH_ACTION=1024`.

It also adds the option to simply skip step updates altogether:
- `xray.steps.update: false`
- `XRAY_STEPS_UPDATE=false`.