### PR TITLE
Fix `normalizeScreenshotNames` setting being ignored

### DIFF
--- a/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -33,11 +33,12 @@ export class ImportExecutionResultsConverterCloud extends ImportExecutionResults
         if (CONTEXT.config.xray.uploadScreenshots) {
             attempt.screenshots.forEach(
                 (screenshot: CypressCommandLine.ScreenshotInformation) => {
-                    const suffix = screenshot.path.substring(
-                        screenshot.path.indexOf("cypress")
-                    );
+                    let filename = basename(screenshot.path);
+                    if (CONTEXT.config.plugin.normalizeScreenshotNames) {
+                        filename = normalizedFilename(filename);
+                    }
                     evidence.push({
-                        filename: normalizedFilename(basename(suffix)),
+                        filename: filename,
                         data: encodeFile(screenshot.path),
                     });
                 }

--- a/src/conversion/importExecutionResults/importExecutionResultsConverterServer.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterServer.ts
@@ -33,11 +33,12 @@ export class ImportExecutionResultsConverterServer extends ImportExecutionResult
         if (CONTEXT.config.xray.uploadScreenshots) {
             attempt.screenshots.forEach(
                 (screenshot: CypressCommandLine.ScreenshotInformation) => {
-                    const suffix = screenshot.path.substring(
-                        screenshot.path.indexOf("cypress")
-                    );
+                    let filename: string = basename(screenshot.path);
+                    if (CONTEXT.config.plugin.normalizeScreenshotNames) {
+                        filename = normalizedFilename(filename);
+                    }
                     evidence.push({
-                        filename: normalizedFilename(basename(suffix)),
+                        filename: filename,
                         data: encodeFile(screenshot.path),
                     });
                 }

--- a/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -150,8 +150,6 @@ describe("the conversion function", () => {
         const json: XrayTestExecutionResultsCloud =
             converter.convertExecutionResults(result);
         expectToExist(json.tests);
-        expect(json.tests).to.have.length(1);
-        expect(json.tests[0].evidence).to.have.length(1);
         expectToExist(json.tests[0].evidence);
         expect(json.tests[0].evidence[0].filename).to.eq(
             "t_rtle_with_problem_tic_name.png"
@@ -165,12 +163,9 @@ describe("the conversion function", () => {
                 "utf-8"
             )
         );
-        expectToExist(CONTEXT.config.plugin);
         const json: XrayTestExecutionResultsCloud =
             converter.convertExecutionResults(result);
         expectToExist(json.tests);
-        expect(json.tests).to.have.length(1);
-        expect(json.tests[0].evidence).to.have.length(1);
         expectToExist(json.tests[0].evidence);
         expect(json.tests[0].evidence[0].filename).to.eq(
             "tûrtle with problemätic name.png"

--- a/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -138,7 +138,7 @@ describe("the conversion function", () => {
         expect(json.tests[2].testInfo).to.not.be.undefined;
     });
 
-    it("should be able to normalize screenshot filenames", () => {
+    it("should normalize screenshot filenames if enabled", () => {
         let result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync(
                 "./test/resources/runResultProblematicScreenshot.json",
@@ -155,6 +155,25 @@ describe("the conversion function", () => {
         expectToExist(json.tests[0].evidence);
         expect(json.tests[0].evidence[0].filename).to.eq(
             "t_rtle_with_problem_tic_name.png"
+        );
+    });
+
+    it("should not normalize screenshot filenames if disabled", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync(
+                "./test/resources/runResultProblematicScreenshot.json",
+                "utf-8"
+            )
+        );
+        expectToExist(CONTEXT.config.plugin);
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+        expectToExist(json.tests);
+        expect(json.tests).to.have.length(1);
+        expect(json.tests[0].evidence).to.have.length(1);
+        expectToExist(json.tests[0].evidence);
+        expect(json.tests[0].evidence[0].filename).to.eq(
+            "tûrtle with problemätic name.png"
         );
     });
 


### PR DESCRIPTION
This PR addresses the `normalizeScreenshotNames` option not being used at all.