### PR TITLE
Add option to configure test execution issue summaries

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,8 @@ export const ENV_JIRA_TEST_EXECUTION_ISSUE_KEY =
 export const ENV_JIRA_TEST_PLAN_ISSUE_KEY = "JIRA_TEST_PLAN_ISSUE_KEY";
 export const ENV_JIRA_ATTACH_VIDEOS = "JIRA_ATTACH_VIDEOS";
 export const ENV_JIRA_CREATE_TEST_ISSUES = "JIRA_CREATE_TEST_ISSUES";
+export const ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY =
+    "JIRA_TEST_EXECUTION_ISSUE_SUMMARY";
 // ================================= //
 // | Xray Configuration            | //
 // ================================= //

--- a/src/context.ts
+++ b/src/context.ts
@@ -22,7 +22,7 @@ export function initContext(config: Options) {
     };
 }
 
-// Set some default values.
+// Set some default values for constant options.
 
 const DEFAULT_OPTIONS_JIRA: JiraOptions = {
     projectKey: null,

--- a/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
@@ -275,7 +275,10 @@ export abstract class ImportExecutionResultsConverter<
     private getTextExecutionResultSummary(
         results: CypressCommandLine.CypressRunResult
     ): string {
-        return `Execution Results [${Date.now()}]`;
+        return (
+            CONTEXT.config.jira.testExecutionIssueSummary ||
+            `Execution Results [${new Date(results.startedTestsAt).getTime()}]`
+        );
     }
 
     private getDescription(

--- a/src/types/xray/plugin.ts
+++ b/src/types/xray/plugin.ts
@@ -51,6 +51,18 @@ export interface JiraOptions {
      * have not been mapped to existing test issues.
      */
     createTestIssues?: boolean;
+    /**
+     * The summary of the test execution issue, which will either be used for
+     * new test execution issues or for updating existing issues (if provided
+     * through {@link JiraOptions.testExecutionIssueKey}).
+     *
+     * If omitted, new test execution issues will be named:
+     * ```ts
+     * `Execution Results [${t}]`,
+     * ```
+     * where `t` is the timestamp when Cypress started testing.
+     */
+    testExecutionIssueSummary?: string;
 }
 
 export interface XrayStepOptions {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -16,6 +16,7 @@ import {
     ENV_JIRA_PASSWORD,
     ENV_JIRA_PROJECT_KEY,
     ENV_JIRA_TEST_EXECUTION_ISSUE_KEY,
+    ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY,
     ENV_JIRA_TEST_PLAN_ISSUE_KEY,
     ENV_JIRA_URL,
     ENV_JIRA_USERNAME,
@@ -62,6 +63,10 @@ export function parseEnvironmentVariables(env: Cypress.ObjectLike): void {
         CONTEXT.config.jira.createTestIssues = parseBoolean(
             env[ENV_JIRA_CREATE_TEST_ISSUES]
         );
+    }
+    if (ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY in env) {
+        CONTEXT.config.jira.testExecutionIssueSummary =
+            env[ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY];
     }
     // Xray.
     if (ENV_XRAY_UPLOAD_RESULTS in env) {

--- a/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -279,4 +279,27 @@ describe("the conversion function", () => {
         expectToExist(json.tests[2].testInfo.steps);
         expect(json.tests[2].testInfo.steps[0].action.length).to.eq(5);
     });
+
+    it("should include a custom test execution summary if provided", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync("./test/resources/runResult.json", "utf-8")
+        );
+        expectToExist(CONTEXT.config.jira);
+        CONTEXT.config.jira.testExecutionIssueSummary = "Jeffrey's Test";
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+        expectToExist(json.info);
+        expect(json.info.summary).to.eq("Jeffrey's Test");
+    });
+
+    it("should use a timestamp as test execution summary by default", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync("./test/resources/runResult.json", "utf-8")
+        );
+        expectToExist(CONTEXT.config.jira);
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+        expectToExist(json.info);
+        expect(json.info.summary).to.eq(`Execution Results [1669657272234]`);
+    });
 });


### PR DESCRIPTION
This PR adds the option to configure test execution issue summaries (see #55) through:
- Configuration:
  ```ts
  jira: {
    testExecutionIssueSummary: "My custom summary"
  }
  ```
- Environment variable:
  ```sh
  JIRA_TEST_EXECUTION_ISSUE_SUMMARY="My custom summary"
  ```

If omitted, the current summary behaviour will be used as fallback, i.e.:
```ts
`Execution Results [${t}]`
```
where `t` is the Unix timestamp when Cypress started testing.
