### PR TITLE
Add option to configure test execution issue descriptions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,8 @@ export const ENV_JIRA_ATTACH_VIDEOS = "JIRA_ATTACH_VIDEOS";
 export const ENV_JIRA_CREATE_TEST_ISSUES = "JIRA_CREATE_TEST_ISSUES";
 export const ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY =
     "JIRA_TEST_EXECUTION_ISSUE_SUMMARY";
+export const ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION =
+    "JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION";
 // ================================= //
 // | Xray Configuration            | //
 // ================================= //

--- a/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
@@ -285,13 +285,14 @@ export abstract class ImportExecutionResultsConverter<
         results: CypressCommandLine.CypressRunResult
     ): string {
         return (
+            CONTEXT.config.jira.testExecutionIssueDescription ||
             "Cypress version: " +
-            results.cypressVersion +
-            " Browser: " +
-            results.browserName +
-            " (" +
-            results.browserVersion +
-            ")"
+                results.cypressVersion +
+                " Browser: " +
+                results.browserName +
+                " (" +
+                results.browserVersion +
+                ")"
         );
     }
 

--- a/src/types/xray/plugin.ts
+++ b/src/types/xray/plugin.ts
@@ -52,17 +52,28 @@ export interface JiraOptions {
      */
     createTestIssues?: boolean;
     /**
-     * The summary of the test execution issue, which will either be used for
-     * new test execution issues or for updating existing issues (if provided
-     * through {@link JiraOptions.testExecutionIssueKey}).
+     * The summary of the test execution issue, which will be used both for new
+     * test execution issues as well as for updating existing issues (if
+     * provided through {@link JiraOptions.testExecutionIssueKey}).
      *
-     * If omitted, new test execution issues will be named:
+     * If omitted, test execution issues will be named as follows:
      * ```ts
      * `Execution Results [${t}]`,
      * ```
      * where `t` is the timestamp when Cypress started testing.
      */
     testExecutionIssueSummary?: string;
+    /**
+     * The description of the test execution issue, which will be used both for
+     * new test execution issues as well as for updating existing issues (if
+     * provided through {@link JiraOptions.testExecutionIssueKey}).
+     *
+     * If omitted, test execution issues will have the following description:
+     * ```ts
+     * `Cypress version: ${cypressVersion} Browser: ${browserName} (${browserVersion})`
+     * ```
+     */
+    testExecutionIssueDescription?: string;
 }
 
 export interface XrayStepOptions {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -15,6 +15,7 @@ import {
     ENV_JIRA_CREATE_TEST_ISSUES,
     ENV_JIRA_PASSWORD,
     ENV_JIRA_PROJECT_KEY,
+    ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION,
     ENV_JIRA_TEST_EXECUTION_ISSUE_KEY,
     ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY,
     ENV_JIRA_TEST_PLAN_ISSUE_KEY,
@@ -67,6 +68,10 @@ export function parseEnvironmentVariables(env: Cypress.ObjectLike): void {
     if (ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY in env) {
         CONTEXT.config.jira.testExecutionIssueSummary =
             env[ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY];
+    }
+    if (ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION in env) {
+        CONTEXT.config.jira.testExecutionIssueDescription =
+            env[ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION];
     }
     // Xray.
     if (ENV_XRAY_UPLOAD_RESULTS in env) {

--- a/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -300,6 +300,31 @@ describe("the conversion function", () => {
         const json: XrayTestExecutionResultsCloud =
             converter.convertExecutionResults(result);
         expectToExist(json.info);
-        expect(json.info.summary).to.eq(`Execution Results [1669657272234]`);
+        expect(json.info.summary).to.eq("Execution Results [1669657272234]");
+    });
+
+    it("should include a custom test execution description if provided", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync("./test/resources/runResult.json", "utf-8")
+        );
+        expectToExist(CONTEXT.config.jira);
+        CONTEXT.config.jira.testExecutionIssueDescription = "Very Useful Text";
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+        expectToExist(json.info);
+        expect(json.info.description).to.eq("Very Useful Text");
+    });
+
+    it("should use versions as test execution description by default", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync("./test/resources/runResult.json", "utf-8")
+        );
+        expectToExist(CONTEXT.config.jira);
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+        expectToExist(json.info);
+        expect(json.info.description).to.eq(
+            "Cypress version: 11.1.0 Browser: electron (106.0.5249.51)"
+        );
     });
 });


### PR DESCRIPTION
This PR adds the option to configure test execution issue descriptions (see #55) through:
- Configuration:
  ```ts
  jira: {
    testExecutionIssueDescription: "My custom description"
  }
  ```
- Environment variable:
  ```sh
  JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION="My custom description"
  ```

If omitted, the current description behaviour will be used as fallback, e.g.:
```ts
"Cypress version: 11.1.0 Browser: electron (106.0.5249.51)"
```
