### PR TITLE
Fix new test cases being skipped during issue creation

### DIFF
--- a/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
@@ -56,7 +56,10 @@ export abstract class ImportExecutionResultsConverter<
                     if (issueKey !== null) {
                         test.testKey = issueKey;
                     }
-                    if (CONTEXT.config.plugin.overwriteIssueSummary) {
+                    if (
+                        issueKey === null ||
+                        CONTEXT.config.plugin.overwriteIssueSummary
+                    ) {
                         test.testInfo = this.getTestInfo(testResult);
                     }
                     if (!json.tests) {

--- a/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverter.ts
@@ -41,25 +41,21 @@ export abstract class ImportExecutionResultsConverter<
                 // TODO: Support multiple iterations.
                 const testResult = testResults[testResults.length - 1];
                 try {
-                    const issueKey = this.getTestIssueKey(testResult);
-                    if (
-                        issueKey === null &&
-                        !CONTEXT.config.jira.createTestIssues
-                    ) {
-                        throw new Error(
-                            "No test issue key found in test title"
-                        );
-                    }
                     const attempts = attemptsByTitle.get(title);
                     // TODO: Support multiple iterations.
                     test = this.getTest(attempts[attempts.length - 1]);
+                    const issueKey = this.getTestIssueKey(testResult);
                     if (issueKey !== null) {
                         test.testKey = issueKey;
-                    }
-                    if (
-                        issueKey === null ||
-                        CONTEXT.config.plugin.overwriteIssueSummary
-                    ) {
+                        if (CONTEXT.config.plugin.overwriteIssueSummary) {
+                            test.testInfo = this.getTestInfo(testResult);
+                        }
+                    } else {
+                        if (!CONTEXT.config.jira.createTestIssues) {
+                            throw new Error(
+                                "No test issue key found in test title"
+                            );
+                        }
                         test.testInfo = this.getTestInfo(testResult);
                     }
                     if (!json.tests) {

--- a/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/test/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -147,6 +147,22 @@ describe("the conversion function", () => {
         expect(json.tests[2].testInfo).to.not.be.undefined;
     });
 
+    it("should be able to create test issues with summary overwriting disabled", () => {
+        let result: CypressCommandLine.CypressRunResult = JSON.parse(
+            readFileSync("./test/resources/runResult.json", "utf-8")
+        );
+        CONTEXT.config.plugin = {
+            overwriteIssueSummary: false,
+        };
+        const json: XrayTestExecutionResultsCloud =
+            converter.convertExecutionResults(result);
+        expectToExist(json.tests);
+        expect(json.tests).to.have.length(3);
+        expect(json.tests[0].testInfo).to.exist;
+        expect(json.tests[1].testInfo).to.exist;
+        expect(json.tests[2].testInfo).to.exist;
+    });
+
     it("should normalize screenshot filenames if enabled", () => {
         let result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync(


### PR DESCRIPTION
This PR fixes test issues not being created if `plugin.overwriteIssueSummary` is disabled, which should not happen for entirely new test cases. See https://github.com/Qytera-Gmbh/cypress-xray-plugin/issues/47#issuecomment-1544176801.