### PR TITLE
Move Cucumber tag extraction to `beforeRunHook`

### DIFF
--- a/test/constants.ts
+++ b/test/constants.ts
@@ -10,7 +10,7 @@ import * as logging from "../src/logging/logging";
 chai.use(sinonChai);
 
 export const stubLogInfo = () => stub(logging, "logInfo");
-export const stubOnLogError = () => stub(logging, "logError");
+export const stubLogError = () => stub(logging, "logError");
 export const stubLogSuccess = () => stub(logging, "logSuccess");
 export const stubLogWarning = () => stub(logging, "logWarning");
 export const stubLogDebug = () => stub(logging, "logDebug");

--- a/test/resources/features/invalid.feature
+++ b/test/resources/features/invalid.feature
@@ -1,0 +1,15 @@
+Feature: A feature
+
+  This is an invalid feature file.
+
+  Background:
+    Given abc123
+    Then xyz987
+
+  Invalid: Element
+
+  Scenario: A scenario
+    Given an assumption
+    When a when
+    And an and
+    Then a then

--- a/test/resources/features/taggedCloudExamples.feature
+++ b/test/resources/features/taggedCloudExamples.feature
@@ -1,0 +1,18 @@
+Feature: A tagged feature with examples
+
+  Feature file for example parsing purposes.
+
+  @TestName:CYP-123
+  Scenario Outline: A tagged scenario with examples
+    Given a <Header 1>
+    When a <Header 2>
+    Then <Header 3>
+
+    Examples:
+      | Header 1 | Header 2 | Header 3 |
+      | A 1      | A 2      | A 3      |
+      | B 1      | B 2      | B 3      |
+
+    Examples:
+      | Header 1 | Header 2 | Header 3 |
+      | C 1      | C 2      | C 3      |

--- a/test/resources/features/taggedServerMultiple.feature
+++ b/test/resources/features/taggedServerMultiple.feature
@@ -1,0 +1,7 @@
+Feature: A tagged feature belonging to a different project
+
+  @CYP-123 @CYP-456 @CYP-789
+  Scenario: A tagged scenario
+    Given an assumption
+    When something
+    Then crash

--- a/test/resources/features/taggedServerUnrelated.feature
+++ b/test/resources/features/taggedServerUnrelated.feature
@@ -1,0 +1,7 @@
+Feature: A tagged feature belonging to a different project
+
+  @FZR-2000
+  Scenario: A tagged scenario
+    Given an assumption
+    When something
+    Then crash

--- a/test/src/cucumber/tagging.ts
+++ b/test/src/cucumber/tagging.ts
@@ -4,6 +4,7 @@ import { expect } from "chai";
 import { CONTEXT, initContext } from "../../../src/context";
 import { issuesByScenario } from "../../../src/cucumber/tagging";
 import { parseFeatureFile } from "../../../src/util/parsing";
+import { stubLogError, stubLogInfo } from "../../constants";
 import { DummyXrayClient, expectToExist } from "../helpers";
 
 describe("the cucumber tag extractor", () => {
@@ -16,7 +17,7 @@ describe("the cucumber tag extractor", () => {
         CONTEXT.xrayClient = new DummyXrayClient();
     });
 
-    it("should be able to extract Xray server tags", async () => {
+    it("should be able to extract Xray server tags", () => {
         const feature = parseFeatureFile("./test/resources/features/taggedServer.feature").feature;
         expectToExist(feature);
         const issueMapping = issuesByScenario(feature, CONTEXT.config.jira.projectKey);
@@ -24,11 +25,37 @@ describe("the cucumber tag extractor", () => {
         expect(issueMapping["A tagged scenario"]).to.eq("CYP-103");
     });
 
-    it("should be able to extract Xray cloud tags", async () => {
+    it("should be able to extract Xray cloud tags", () => {
         const feature = parseFeatureFile("./test/resources/features/taggedCloud.feature").feature;
         expectToExist(feature);
         const issueMapping = issuesByScenario(feature, CONTEXT.config.jira.projectKey);
         expect(issueMapping).to.have.key("A tagged scenario");
         expect(issueMapping["A tagged scenario"]).to.eq("CYP-857");
+    });
+
+    it("should be able to skip unrelated tags", () => {
+        const feature = parseFeatureFile(
+            "./test/resources/features/taggedServerUnrelated.feature"
+        ).feature;
+        const stubbedInfo = stubLogInfo();
+        const issueMapping = issuesByScenario(feature, CONTEXT.config.jira.projectKey);
+        expect(issueMapping).to.be.empty;
+        expect(stubbedInfo).to.have.been.called.with.callCount(1);
+        expect(stubbedInfo).to.have.been.calledWith(
+            'No issue keys found in tags of scenario "A tagged scenario".'
+        );
+    });
+
+    it("should be able to warn about multiple tags", () => {
+        const feature = parseFeatureFile(
+            "./test/resources/features/taggedServerMultiple.feature"
+        ).feature;
+        const stubbedError = stubLogError();
+        const issueMapping = issuesByScenario(feature, CONTEXT.config.jira.projectKey);
+        expect(issueMapping).to.be.empty;
+        expect(stubbedError).to.have.been.called.with.callCount(1);
+        expect(stubbedError).to.have.been.calledWith(
+            'Multiple issue keys found in tags of scenario "A tagged scenario": CYP-123, CYP-456, CYP-789'
+        );
     });
 });


### PR DESCRIPTION
This PR moves the Cucumber extraction to the general `beforeRunHook` to make `syncFeatureFiles` only deal with feature file synchronization (as planned).