### PR TITLE
Use nullish coalescing instead of falsy evaluation

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -8,8 +8,8 @@ export function initContext(config: Options) {
         config: {
             jira: {
                 projectKey: config.jira?.projectKey,
-                attachVideos: config.jira?.attachVideos || false,
-                createTestIssues: config.jira?.createTestIssues || true,
+                attachVideos: config.jira?.attachVideos ?? false,
+                createTestIssues: config.jira?.createTestIssues ?? true,
                 testExecutionIssueDescription: config.jira?.testExecutionIssueDescription,
                 testExecutionIssueKey: config.jira?.testExecutionIssueKey,
                 testExecutionIssueSummary: config.jira?.testExecutionIssueSummary,
@@ -17,9 +17,9 @@ export function initContext(config: Options) {
                 url: config.jira?.url,
             },
             plugin: {
-                overwriteIssueSummary: config.plugin?.overwriteIssueSummary || false,
-                normalizeScreenshotNames: config.plugin?.normalizeScreenshotNames || false,
-                debug: config.plugin?.debug || false,
+                overwriteIssueSummary: config.plugin?.overwriteIssueSummary ?? false,
+                normalizeScreenshotNames: config.plugin?.normalizeScreenshotNames ?? false,
+                debug: config.plugin?.debug ?? false,
             },
             xray: {
                 statusFailed: config.xray?.statusFailed,
@@ -27,18 +27,18 @@ export function initContext(config: Options) {
                 statusPending: config.xray?.statusPending,
                 statusSkipped: config.xray?.statusSkipped,
                 steps: {
-                    maxLengthAction: config.xray?.steps?.maxLengthAction || 8000,
-                    update: config.xray?.steps?.update || true,
+                    maxLengthAction: config.xray?.steps?.maxLengthAction ?? 8000,
+                    update: config.xray?.steps?.update ?? true,
                 },
-                testType: config.xray?.testType || "Manual",
-                uploadResults: config.xray?.uploadResults || true,
-                uploadScreenshots: config.xray?.uploadScreenshots || true,
+                testType: config.xray?.testType ?? "Manual",
+                uploadResults: config.xray?.uploadResults ?? true,
+                uploadScreenshots: config.xray?.uploadScreenshots ?? true,
             },
             cucumber: {
                 featureFileExtension: config.cucumber?.featureFileExtension,
-                downloadFeatures: config.cucumber?.downloadFeatures || false,
+                downloadFeatures: config.cucumber?.downloadFeatures ?? false,
                 issues: undefined,
-                uploadFeatures: config.cucumber?.uploadFeatures || false,
+                uploadFeatures: config.cucumber?.uploadFeatures ?? false,
             },
             openSSL: {
                 rootCAPath: config.openSSL?.rootCAPath,

--- a/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.ts
@@ -45,13 +45,13 @@ export class ImportExecutionResultsConverterCloud extends ImportExecutionResults
     protected getXrayStatus(status: Status): string {
         switch (status) {
             case Status.PASSED:
-                return CONTEXT.config.xray.statusPassed || "PASSED";
+                return CONTEXT.config.xray.statusPassed ?? "PASSED";
             case Status.FAILED:
-                return CONTEXT.config.xray.statusFailed || "FAILED";
+                return CONTEXT.config.xray.statusFailed ?? "FAILED";
             case Status.PENDING:
-                return CONTEXT.config.xray.statusPending || "TODO";
+                return CONTEXT.config.xray.statusPending ?? "TODO";
             case Status.SKIPPED:
-                return CONTEXT.config.xray.statusSkipped || "FAILED";
+                return CONTEXT.config.xray.statusSkipped ?? "FAILED";
             default:
                 throw new Error(`Unknown status: '${status}'`);
         }

--- a/src/conversion/importExecutionResults/importExecutionResultsConverterServer.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterServer.ts
@@ -45,13 +45,13 @@ export class ImportExecutionResultsConverterServer extends ImportExecutionResult
     protected getXrayStatus(status: Status): string {
         switch (status) {
             case Status.PASSED:
-                return CONTEXT.config.xray.statusPassed || "PASS";
+                return CONTEXT.config.xray.statusPassed ?? "PASS";
             case Status.FAILED:
-                return CONTEXT.config.xray.statusFailed || "FAIL";
+                return CONTEXT.config.xray.statusFailed ?? "FAIL";
             case Status.PENDING:
-                return CONTEXT.config.xray.statusPending || "TODO";
+                return CONTEXT.config.xray.statusPending ?? "TODO";
             case Status.SKIPPED:
-                return CONTEXT.config.xray.statusSkipped || "FAIL";
+                return CONTEXT.config.xray.statusSkipped ?? "FAIL";
             default:
                 throw new Error(`Unknown status: '${status}'`);
         }

--- a/test/src/context.ts
+++ b/test/src/context.ts
@@ -1,0 +1,366 @@
+/// <reference types="cypress" />
+
+import { expect } from "chai";
+import { CONTEXT, initContext } from "../../src/context";
+
+describe("the context configuration", () => {
+    describe("should have certain default values", () => {
+        before(() => {
+            initContext({
+                jira: {
+                    projectKey: "PRJ",
+                },
+            });
+        });
+
+        describe("jira", () => {
+            it("attachVideos", () => {
+                expect(CONTEXT.config.jira.attachVideos).to.eq(false);
+            });
+            it("attachCreateTestIssues", () => {
+                expect(CONTEXT.config.jira.createTestIssues).to.eq(true);
+            });
+            it("testExecutionIssueDescription", () => {
+                expect(CONTEXT.config.jira.testExecutionIssueDescription).to.eq(undefined);
+            });
+            it("testExecutionIssueKey", () => {
+                expect(CONTEXT.config.jira.testExecutionIssueKey).to.eq(undefined);
+            });
+            it("testExecutionIssueSummary", () => {
+                expect(CONTEXT.config.jira.testExecutionIssueSummary).to.eq(undefined);
+            });
+            it("testPlanIssueKey", () => {
+                expect(CONTEXT.config.jira.testPlanIssueKey).to.eq(undefined);
+            });
+            it("url", () => {
+                expect(CONTEXT.config.jira.url).to.eq(undefined);
+            });
+        });
+
+        describe("plugin", () => {
+            it("overwriteIssueSummary", () => {
+                expect(CONTEXT.config.plugin.overwriteIssueSummary).to.eq(false);
+            });
+            it("normalizeScreenshotNames", () => {
+                expect(CONTEXT.config.plugin.normalizeScreenshotNames).to.eq(false);
+            });
+            it("debug", () => {
+                expect(CONTEXT.config.plugin.debug).to.eq(false);
+            });
+        });
+
+        describe("xray", () => {
+            it("statusFailed", () => {
+                expect(CONTEXT.config.xray.statusFailed).to.eq(undefined);
+            });
+            it("statusPassed", () => {
+                expect(CONTEXT.config.xray.statusPassed).to.eq(undefined);
+            });
+            it("statusPending", () => {
+                expect(CONTEXT.config.xray.statusPending).to.eq(undefined);
+            });
+            it("statusSkipped", () => {
+                expect(CONTEXT.config.xray.statusSkipped).to.eq(undefined);
+            });
+            describe("steps", () => {
+                it("maxLengthAction", () => {
+                    expect(CONTEXT.config.xray.steps.maxLengthAction).to.eq(8000);
+                });
+                it("update", () => {
+                    expect(CONTEXT.config.xray.steps.update).to.eq(true);
+                });
+            });
+            it("testType", () => {
+                expect(CONTEXT.config.xray.testType).to.eq("Manual");
+            });
+            it("uploadResults", () => {
+                expect(CONTEXT.config.xray.uploadResults).to.eq(true);
+            });
+            it("uploadScreenshots", () => {
+                expect(CONTEXT.config.xray.uploadScreenshots).to.eq(true);
+            });
+        });
+
+        describe("cucumber", () => {
+            it("downloadFeatures", () => {
+                expect(CONTEXT.config.cucumber.downloadFeatures).to.eq(false);
+            });
+            it("uploadFeatures", () => {
+                expect(CONTEXT.config.cucumber.uploadFeatures).to.eq(false);
+            });
+        });
+
+        describe("openSSL", () => {
+            it("openSSL", () => {
+                expect(CONTEXT.config.openSSL.rootCAPath).to.eq(undefined);
+            });
+            it("uploadFeatures", () => {
+                expect(CONTEXT.config.openSSL.secureOptions).to.eq(undefined);
+            });
+        });
+    });
+    describe("should prefer provided values over default ones", () => {
+        describe("jira", () => {
+            it("attachVideos", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                        attachVideos: true,
+                    },
+                });
+                expect(CONTEXT.config.jira.attachVideos).to.eq(true);
+            });
+            it("createTestIssues", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                        createTestIssues: false,
+                    },
+                });
+                expect(CONTEXT.config.jira.createTestIssues).to.eq(false);
+            });
+            it("testExecutionIssueDescription", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                        testExecutionIssueDescription: "hello",
+                    },
+                });
+                expect(CONTEXT.config.jira.testExecutionIssueDescription).to.eq("hello");
+            });
+            it("testExecutionIssueKey", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                        testExecutionIssueKey: "PRJ-123",
+                    },
+                });
+                expect(CONTEXT.config.jira.testExecutionIssueKey).to.eq("PRJ-123");
+            });
+            it("testExecutionIssueSummary", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                        testExecutionIssueSummary: "Test - Login",
+                    },
+                });
+                expect(CONTEXT.config.jira.testExecutionIssueSummary).to.eq("Test - Login");
+            });
+            it("testPlanIssueKey", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                        testPlanIssueKey: "PRJ-456",
+                    },
+                });
+                expect(CONTEXT.config.jira.testPlanIssueKey).to.eq("PRJ-456");
+            });
+            it("url", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                        url: "https://example.org",
+                    },
+                });
+                expect(CONTEXT.config.jira.url).to.eq("https://example.org");
+            });
+        });
+
+        describe("plugin", () => {
+            it("overwriteIssueSummary", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    plugin: {
+                        overwriteIssueSummary: true,
+                    },
+                });
+                expect(CONTEXT.config.plugin.overwriteIssueSummary).to.eq(true);
+            });
+            it("normalizeScreenshotNames", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    plugin: {
+                        normalizeScreenshotNames: true,
+                    },
+                });
+                expect(CONTEXT.config.plugin.normalizeScreenshotNames).to.eq(true);
+            });
+            it("debug", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    plugin: {
+                        debug: true,
+                    },
+                });
+                expect(CONTEXT.config.plugin.debug).to.eq(true);
+            });
+        });
+
+        describe("xray", () => {
+            it("statusFailed", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    xray: {
+                        statusFailed: "BAD",
+                    },
+                });
+                expect(CONTEXT.config.xray.statusFailed).to.eq("BAD");
+            });
+            it("statusPassed", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    xray: {
+                        statusPassed: "GOOD",
+                    },
+                });
+                expect(CONTEXT.config.xray.statusPassed).to.eq("GOOD");
+            });
+            it("statusPending", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    xray: {
+                        statusPending: "PENDULUM",
+                    },
+                });
+                expect(CONTEXT.config.xray.statusPending).to.eq("PENDULUM");
+            });
+            it("statusSkipped", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    xray: {
+                        statusSkipped: "SKIPPING STONE",
+                    },
+                });
+                expect(CONTEXT.config.xray.statusSkipped).to.eq("SKIPPING STONE");
+            });
+
+            describe("steps", () => {
+                it("maxLengthAction", () => {
+                    initContext({
+                        jira: {
+                            projectKey: "PRJ",
+                        },
+                        xray: {
+                            steps: {
+                                maxLengthAction: 42,
+                            },
+                        },
+                    });
+                    expect(CONTEXT.config.xray.steps.maxLengthAction).to.eq(42);
+                });
+                it("update", () => {
+                    initContext({
+                        jira: {
+                            projectKey: "PRJ",
+                        },
+                        xray: {
+                            steps: {
+                                update: false,
+                            },
+                        },
+                    });
+                    expect(CONTEXT.config.xray.steps.update).to.eq(false);
+                });
+            });
+            it("testType", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    xray: {
+                        testType: "Cucumber",
+                    },
+                });
+                expect(CONTEXT.config.xray.testType).to.eq("Cucumber");
+            });
+            it("uploadResults", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    xray: {
+                        uploadResults: false,
+                    },
+                });
+                expect(CONTEXT.config.xray.uploadResults).to.eq(false);
+            });
+            it("uploadScreenshots", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    xray: {
+                        uploadScreenshots: false,
+                    },
+                });
+                expect(CONTEXT.config.xray.uploadScreenshots).to.eq(false);
+            });
+        });
+
+        describe("cucumber", () => {
+            it("downloadFeatures", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    cucumber: {
+                        featureFileExtension: ".feature",
+                        downloadFeatures: true,
+                    },
+                });
+                expect(CONTEXT.config.cucumber.downloadFeatures).to.eq(true);
+            });
+            it("uploadFeatures", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    cucumber: {
+                        featureFileExtension: ".feature",
+                        uploadFeatures: true,
+                    },
+                });
+                expect(CONTEXT.config.cucumber.uploadFeatures).to.eq(true);
+            });
+        });
+
+        describe("openSSL", () => {
+            it("rootCAPath", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    openSSL: {
+                        rootCAPath: "/path/to/cert.pem",
+                    },
+                });
+                expect(CONTEXT.config.openSSL.rootCAPath).to.eq("/path/to/cert.pem");
+            });
+            it("secureOptions", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    openSSL: {
+                        secureOptions: 42,
+                    },
+                });
+                expect(CONTEXT.config.openSSL.secureOptions).to.eq(42);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR fixes incorrectly overwritten configuration values due to falsy evaluation instead of nullish coalescence. The bug occurs when a falsy value has been configured, which is then overwritten with the default value.

For example, configuring
```ts
jira: {
  createTestIssues: false
}
```
is always reset to its default value `true` because of falsy evaluation.