### PR TITLE
Add `plugin.enabled` option

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,38 +11,39 @@ export const ENV_JIRA_API_TOKEN = "JIRA_API_TOKEN";
 // ============================================================================================== //
 // | Jira Configuration                                                                         | //
 // ============================================================================================== //
-export const ENV_JIRA_PROJECT_KEY = "JIRA_PROJECT_KEY";
-export const ENV_JIRA_URL = "JIRA_URL";
-export const ENV_JIRA_TEST_EXECUTION_ISSUE_KEY = "JIRA_TEST_EXECUTION_ISSUE_KEY";
-export const ENV_JIRA_TEST_PLAN_ISSUE_KEY = "JIRA_TEST_PLAN_ISSUE_KEY";
 export const ENV_JIRA_ATTACH_VIDEOS = "JIRA_ATTACH_VIDEOS";
 export const ENV_JIRA_CREATE_TEST_ISSUES = "JIRA_CREATE_TEST_ISSUES";
-export const ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY = "JIRA_TEST_EXECUTION_ISSUE_SUMMARY";
+export const ENV_JIRA_PROJECT_KEY = "JIRA_PROJECT_KEY";
 export const ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION = "JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION";
+export const ENV_JIRA_TEST_EXECUTION_ISSUE_KEY = "JIRA_TEST_EXECUTION_ISSUE_KEY";
+export const ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY = "JIRA_TEST_EXECUTION_ISSUE_SUMMARY";
+export const ENV_JIRA_TEST_PLAN_ISSUE_KEY = "JIRA_TEST_PLAN_ISSUE_KEY";
+export const ENV_JIRA_URL = "JIRA_URL";
 // ============================================================================================== //
 // | Xray Configuration                                                                         | //
 // ============================================================================================== //
-export const ENV_XRAY_UPLOAD_RESULTS = "XRAY_UPLOAD_RESULTS";
-export const ENV_XRAY_UPLOAD_SCREENSHOTS = "XRAY_UPLOAD_SCREENSHOTS";
-export const ENV_XRAY_STATUS_PASSED = "XRAY_STATUS_PASSED";
 export const ENV_XRAY_STATUS_FAILED = "XRAY_STATUS_FAILED";
+export const ENV_XRAY_STATUS_PASSED = "XRAY_STATUS_PASSED";
 export const ENV_XRAY_STATUS_PENDING = "XRAY_STATUS_PENDING";
 export const ENV_XRAY_STATUS_SKIPPED = "XRAY_STATUS_SKIPPED";
-export const ENV_XRAY_TEST_TYPE = "XRAY_TEST_TYPE";
-export const ENV_XRAY_STEPS_UPDATE = "XRAY_STEPS_UPDATE";
 export const ENV_XRAY_STEPS_MAX_LENGTH_ACTION = "XRAY_STEPS_MAX_LENGTH_ACTION";
+export const ENV_XRAY_STEPS_UPDATE = "XRAY_STEPS_UPDATE";
+export const ENV_XRAY_TEST_TYPE = "XRAY_TEST_TYPE";
+export const ENV_XRAY_UPLOAD_RESULTS = "XRAY_UPLOAD_RESULTS";
+export const ENV_XRAY_UPLOAD_SCREENSHOTS = "XRAY_UPLOAD_SCREENSHOTS";
 // ============================================================================================== //
 // | Cucumber Configuration                                                                     | //
 // ============================================================================================== //
+export const ENV_CUCUMBER_DOWNLOAD_FEATURES = "CUCUMBER_DOWNLOAD_FEATURES";
 export const ENV_CUCUMBER_FEATURE_FILE_EXTENSION = "CUCUMBER_FEATURE_FILE_EXTENSION";
 export const ENV_CUCUMBER_UPLOAD_FEATURES = "CUCUMBER_UPLOAD_FEATURES";
-export const ENV_CUCUMBER_DOWNLOAD_FEATURES = "CUCUMBER_DOWNLOAD_FEATURES";
 // ============================================================================================== //
 // | Plugin Configuration                                                                       | //
 // ============================================================================================== //
-export const ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY = "PLUGIN_OVERWRITE_ISSUE_SUMMARY";
-export const ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES = "PLUGIN_NORMALIZE_SCREENSHOT_NAMES";
 export const ENV_PLUGIN_DEBUG = "PLUGIN_DEBUG";
+export const ENV_PLUGIN_ENABLED = "PLUGIN_ENABLED";
+export const ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES = "PLUGIN_NORMALIZE_SCREENSHOT_NAMES";
+export const ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY = "PLUGIN_OVERWRITE_ISSUE_SUMMARY";
 // ============================================================================================== //
 // | OpenSSL Configuration                                                                      | //
 // ============================================================================================== //

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,9 +7,9 @@ export function initContext(config: Options) {
     CONTEXT = {
         config: {
             jira: {
-                projectKey: config.jira?.projectKey,
                 attachVideos: config.jira?.attachVideos ?? false,
                 createTestIssues: config.jira?.createTestIssues ?? true,
+                projectKey: config.jira?.projectKey,
                 testExecutionIssueDescription: config.jira?.testExecutionIssueDescription,
                 testExecutionIssueKey: config.jira?.testExecutionIssueKey,
                 testExecutionIssueSummary: config.jira?.testExecutionIssueSummary,
@@ -17,9 +17,10 @@ export function initContext(config: Options) {
                 url: config.jira?.url,
             },
             plugin: {
-                overwriteIssueSummary: config.plugin?.overwriteIssueSummary ?? false,
-                normalizeScreenshotNames: config.plugin?.normalizeScreenshotNames ?? false,
                 debug: config.plugin?.debug ?? false,
+                enabled: config.plugin?.enabled ?? true,
+                normalizeScreenshotNames: config.plugin?.normalizeScreenshotNames ?? false,
+                overwriteIssueSummary: config.plugin?.overwriteIssueSummary ?? false,
             },
             xray: {
                 statusFailed: config.xray?.statusFailed,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -63,8 +63,6 @@ export async function beforeRunHook(runDetails: Cypress.BeforeRunDetails) {
         );
     }
     parseEnvironmentVariables(runDetails.config.env);
-    initXrayClient(runDetails.config.env);
-    initJiraClient(runDetails.config.env);
     verifyJiraProjectKey(CONTEXT.config.jira.projectKey);
     verifyJiraTestExecutionIssueKey(
         CONTEXT.config.jira.projectKey,
@@ -75,6 +73,8 @@ export async function beforeRunHook(runDetails: Cypress.BeforeRunDetails) {
         CONTEXT.config.jira.testPlanIssueKey
     );
     verifyXraySteps(CONTEXT.config.xray.steps);
+    initXrayClient(runDetails.config.env);
+    initJiraClient(runDetails.config.env);
     parseFeatureFiles(runDetails.specs);
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -51,10 +51,6 @@ function parseFeatureFiles(specs: Cypress.Spec[]) {
                     `Feature file "${spec.absolute}" invalid, skipping synchronization: ${error}`
                 );
             }
-        } else {
-            logInfo(
-                `Feature file "${spec.absolute}" does not have extension "${CONTEXT.config.cucumber.featureFileExtension}", skipping synchronization.`
-            );
         }
     });
 }
@@ -68,7 +64,7 @@ export async function beforeRunHook(runDetails: Cypress.BeforeRunDetails) {
     }
     parseEnvironmentVariables(runDetails.config.env);
     if (!CONTEXT.config.plugin.enabled) {
-        logInfo("Plugin disabled. Skipping before:run execution.");
+        logInfo("Plugin disabled. Skipping before:run hook.");
         return;
     }
     verifyJiraProjectKey(CONTEXT.config.jira.projectKey);
@@ -90,7 +86,7 @@ export async function afterRunHook(
     results: CypressCommandLine.CypressRunResult | CypressCommandLine.CypressFailedRunResult
 ) {
     if (!CONTEXT.config.plugin.enabled) {
-        logInfo("Plugin disabled. Skipping after:run execution.");
+        logInfo("Plugin disabled. Skipping after:run hook.");
         return;
     }
     if (results.status === "failed") {
@@ -124,7 +120,9 @@ export async function afterRunHook(
 
 export async function filePreprocessorHook(file: Cypress.FileObject): Promise<string> {
     if (!CONTEXT.config.plugin.enabled) {
-        logInfo("Plugin disabled. Skipping feature file synchronization.");
+        logInfo(
+            `Plugin disabled. Skipping file:preprocessor hook triggered by "${file.filePath}".`
+        );
         return;
     }
     if (file.filePath.endsWith(CONTEXT.config.cucumber.featureFileExtension)) {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -181,6 +181,11 @@ export interface CucumberOptions {
 
 export interface PluginOptions {
     /**
+     * Enables or disables the entire plugin. Setting this option to `false` disables all plugin
+     * functions, including authentication checks, uploads or feature file synchronization.
+     */
+    enabled?: boolean;
+    /**
      * Turns on or off extensive debugging output.
      */
     debug?: boolean;

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -24,6 +24,7 @@ import {
     ENV_OPENSSL_ROOT_CA_PATH,
     ENV_OPENSSL_SECURE_OPTIONS,
     ENV_PLUGIN_DEBUG,
+    ENV_PLUGIN_ENABLED,
     ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES,
     ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY,
     ENV_XRAY_CLIENT_ID,
@@ -40,98 +41,93 @@ import {
 } from "../constants";
 import { CONTEXT } from "../context";
 import { logInfo } from "../logging/logging";
-import { parseBoolean } from "./parsing";
+import { asBoolean, asInt, asString } from "./parsing";
 
 export function parseEnvironmentVariables(env: Cypress.ObjectLike): void {
-    // Jira.
-    if (ENV_JIRA_PROJECT_KEY in env) {
-        CONTEXT.config.jira.projectKey = env[ENV_JIRA_PROJECT_KEY];
-    }
-    if (ENV_JIRA_URL in env) {
-        CONTEXT.config.jira.url = env[ENV_JIRA_URL];
-    }
-    if (ENV_JIRA_TEST_EXECUTION_ISSUE_KEY in env) {
-        CONTEXT.config.jira.testExecutionIssueKey = env[ENV_JIRA_TEST_EXECUTION_ISSUE_KEY];
-    }
-    if (ENV_JIRA_TEST_PLAN_ISSUE_KEY in env) {
-        CONTEXT.config.jira.testPlanIssueKey = env[ENV_JIRA_TEST_PLAN_ISSUE_KEY];
-    }
-    if (ENV_JIRA_ATTACH_VIDEOS in env) {
-        CONTEXT.config.jira.attachVideos = parseBoolean(env[ENV_JIRA_ATTACH_VIDEOS]);
-    }
-    if (ENV_JIRA_CREATE_TEST_ISSUES in env) {
-        CONTEXT.config.jira.createTestIssues = parseBoolean(env[ENV_JIRA_CREATE_TEST_ISSUES]);
-    }
-    if (ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY in env) {
-        CONTEXT.config.jira.testExecutionIssueSummary = env[ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY];
-    }
-    if (ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION in env) {
-        CONTEXT.config.jira.testExecutionIssueDescription =
-            env[ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION];
-    }
-    // Xray.
-    if (ENV_XRAY_TEST_TYPE in env) {
-        CONTEXT.config.xray.testType = env[ENV_XRAY_TEST_TYPE];
-    }
-    if (ENV_XRAY_UPLOAD_RESULTS in env) {
-        CONTEXT.config.xray.uploadResults = parseBoolean(env[ENV_XRAY_UPLOAD_RESULTS]);
-    }
-    if (ENV_XRAY_UPLOAD_SCREENSHOTS in env) {
-        CONTEXT.config.xray.uploadScreenshots = parseBoolean(env[ENV_XRAY_UPLOAD_SCREENSHOTS]);
-    }
-    if (ENV_XRAY_STATUS_PASSED in env) {
-        CONTEXT.config.xray.statusPassed = env[ENV_XRAY_STATUS_PASSED];
-    }
-    if (ENV_XRAY_STATUS_PENDING in env) {
-        CONTEXT.config.xray.statusPending = env[ENV_XRAY_STATUS_PENDING];
-    }
-    if (ENV_XRAY_STATUS_SKIPPED in env) {
-        CONTEXT.config.xray.statusSkipped = env[ENV_XRAY_STATUS_SKIPPED];
-    }
-    if (ENV_XRAY_STATUS_FAILED in env) {
-        CONTEXT.config.xray.statusFailed = env[ENV_XRAY_STATUS_FAILED];
-    }
-    if (ENV_XRAY_STEPS_UPDATE in env) {
-        CONTEXT.config.xray.steps.update = parseBoolean(env[ENV_XRAY_STEPS_UPDATE]);
-    }
-    if (ENV_XRAY_STEPS_MAX_LENGTH_ACTION in env) {
-        CONTEXT.config.xray.steps.maxLengthAction = Number.parseInt(
-            env[ENV_XRAY_STEPS_MAX_LENGTH_ACTION]
-        );
-    }
-    // Cucumber.
-    if (ENV_CUCUMBER_FEATURE_FILE_EXTENSION in env) {
-        CONTEXT.config.cucumber.featureFileExtension = env[ENV_CUCUMBER_FEATURE_FILE_EXTENSION];
-    }
-    if (ENV_CUCUMBER_UPLOAD_FEATURES in env) {
-        CONTEXT.config.cucumber.uploadFeatures = parseBoolean(env[ENV_CUCUMBER_UPLOAD_FEATURES]);
-    }
-    if (ENV_CUCUMBER_DOWNLOAD_FEATURES in env) {
-        CONTEXT.config.cucumber.downloadFeatures = parseBoolean(
-            env[ENV_CUCUMBER_DOWNLOAD_FEATURES]
-        );
-    }
-    // Plugin.
-    if (ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY in env) {
-        CONTEXT.config.plugin.overwriteIssueSummary = parseBoolean(
-            env[ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY]
-        );
-    }
-    if (ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES in env) {
-        CONTEXT.config.plugin.normalizeScreenshotNames = parseBoolean(
-            env[ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES]
-        );
-    }
-    if (ENV_PLUGIN_DEBUG in env) {
-        CONTEXT.config.plugin.debug = parseBoolean(env[ENV_PLUGIN_DEBUG]);
-    }
-    // OpenSSL.
-    if (ENV_OPENSSL_ROOT_CA_PATH in env) {
-        CONTEXT.config.openSSL.rootCAPath = env[ENV_OPENSSL_ROOT_CA_PATH];
-    }
-    if (ENV_OPENSSL_SECURE_OPTIONS in env) {
-        CONTEXT.config.openSSL.secureOptions = env[ENV_OPENSSL_SECURE_OPTIONS];
-    }
+    CONTEXT.config = {
+        jira: {
+            projectKey:
+                parse(env, ENV_JIRA_PROJECT_KEY, asString) ?? CONTEXT.config.jira.projectKey,
+            attachVideos:
+                parse(env, ENV_JIRA_ATTACH_VIDEOS, asBoolean) ?? CONTEXT.config.jira.attachVideos,
+            createTestIssues:
+                parse(env, ENV_JIRA_CREATE_TEST_ISSUES, asBoolean) ??
+                CONTEXT.config.jira.createTestIssues,
+            testExecutionIssueDescription:
+                parse(env, ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION, asString) ??
+                CONTEXT.config.jira.testExecutionIssueDescription,
+            testExecutionIssueKey:
+                parse(env, ENV_JIRA_TEST_EXECUTION_ISSUE_KEY, asString) ??
+                CONTEXT.config.jira.testExecutionIssueKey,
+            testExecutionIssueSummary:
+                parse(env, ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY, asString) ??
+                CONTEXT.config.jira.testExecutionIssueSummary,
+            testPlanIssueKey:
+                parse(env, ENV_JIRA_TEST_PLAN_ISSUE_KEY, asString) ??
+                CONTEXT.config.jira.testPlanIssueKey,
+            url: parse(env, ENV_JIRA_URL, asString) ?? CONTEXT.config.jira.url,
+        },
+        xray: {
+            statusFailed:
+                parse(env, ENV_XRAY_STATUS_FAILED, asString) ?? CONTEXT.config.xray.statusFailed,
+            statusPassed:
+                parse(env, ENV_XRAY_STATUS_PASSED, asString) ?? CONTEXT.config.xray.statusPassed,
+            statusPending:
+                parse(env, ENV_XRAY_STATUS_PENDING, asString) ?? CONTEXT.config.xray.statusPending,
+            statusSkipped:
+                parse(env, ENV_XRAY_STATUS_SKIPPED, asString) ?? CONTEXT.config.xray.statusSkipped,
+            steps: {
+                maxLengthAction:
+                    parse(env, ENV_XRAY_STEPS_MAX_LENGTH_ACTION, asInt) ??
+                    CONTEXT.config.xray.steps.maxLengthAction,
+                update:
+                    parse(env, ENV_XRAY_STEPS_UPDATE, asBoolean) ??
+                    CONTEXT.config.xray.steps.update,
+            },
+            testType: parse(env, ENV_XRAY_TEST_TYPE, asString) ?? CONTEXT.config.xray.testType,
+            uploadResults:
+                parse(env, ENV_XRAY_UPLOAD_RESULTS, asBoolean) ?? CONTEXT.config.xray.uploadResults,
+            uploadScreenshots:
+                parse(env, ENV_XRAY_UPLOAD_SCREENSHOTS, asBoolean) ??
+                CONTEXT.config.xray.uploadScreenshots,
+        },
+        cucumber: {
+            featureFileExtension:
+                parse(env, ENV_CUCUMBER_FEATURE_FILE_EXTENSION, asString) ??
+                CONTEXT.config.cucumber.featureFileExtension,
+            downloadFeatures:
+                parse(env, ENV_CUCUMBER_DOWNLOAD_FEATURES, asBoolean) ??
+                CONTEXT.config.cucumber.downloadFeatures,
+            uploadFeatures:
+                parse(env, ENV_CUCUMBER_UPLOAD_FEATURES, asBoolean) ??
+                CONTEXT.config.cucumber.uploadFeatures,
+        },
+        plugin: {
+            enabled: parse(env, ENV_PLUGIN_ENABLED, asBoolean) ?? CONTEXT.config.plugin.enabled,
+            debug: parse(env, ENV_PLUGIN_DEBUG, asBoolean) ?? CONTEXT.config.plugin.debug,
+            normalizeScreenshotNames:
+                parse(env, ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES, asBoolean) ??
+                CONTEXT.config.plugin.normalizeScreenshotNames,
+            overwriteIssueSummary:
+                parse(env, ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY, asBoolean) ??
+                CONTEXT.config.plugin.overwriteIssueSummary,
+        },
+        openSSL: {
+            rootCAPath:
+                parse(env, ENV_OPENSSL_ROOT_CA_PATH, asString) ?? CONTEXT.config.openSSL.rootCAPath,
+            secureOptions:
+                parse(env, ENV_OPENSSL_SECURE_OPTIONS, asInt) ??
+                CONTEXT.config.openSSL.secureOptions,
+        },
+    };
+}
+
+function parse<T>(
+    env: Cypress.ObjectLike,
+    variable: string,
+    parser: (parameter: string) => T
+): T | undefined {
+    return variable in env ? parser(env[variable]) : undefined;
 }
 
 export function initXrayClient(env: Cypress.ObjectLike): void {

--- a/src/util/parsing.ts
+++ b/src/util/parsing.ts
@@ -9,7 +9,7 @@ import { readFileSync } from "fs";
  * @returns the corresponding boolean value
  * @see https://www.npmjs.com/package/yn
  */
-export function parseBoolean(value: string): boolean {
+export function asBoolean(value: string): boolean {
     value = String(value).trim();
 
     if (/^(?:y|yes|true|1|on)$/i.test(value)) {
@@ -21,6 +21,36 @@ export function parseBoolean(value: string): boolean {
     }
 
     throw new Error(`Failed to parse boolean value from string: ${value}`);
+}
+
+/**
+ * No-op function for consistency purposes.
+ *
+ * @param value the string
+ * @returns the string
+ */
+export function asString(value: string): string {
+    return value;
+}
+
+/**
+ * Parses and returns a float value from a string.
+ *
+ * @param value a string that can be interpreted as a float value
+ * @returns the corresponding float value
+ */
+export function asFloat(value: string): number {
+    return Number.parseFloat(value);
+}
+
+/**
+ * Parses and returns an integer value from a string.
+ *
+ * @param value a string that can be interpreted as an integer value
+ * @returns the corresponding integer value
+ */
+export function asInt(value: string): number {
+    return Number.parseInt(value);
 }
 
 /**

--- a/test/src/context.ts
+++ b/test/src/context.ts
@@ -38,14 +38,17 @@ describe("the context configuration", () => {
         });
 
         describe("plugin", () => {
-            it("overwriteIssueSummary", () => {
-                expect(CONTEXT.config.plugin.overwriteIssueSummary).to.eq(false);
+            it("debug", () => {
+                expect(CONTEXT.config.plugin.debug).to.eq(false);
+            });
+            it("enabled", () => {
+                expect(CONTEXT.config.plugin.enabled).to.eq(true);
             });
             it("normalizeScreenshotNames", () => {
                 expect(CONTEXT.config.plugin.normalizeScreenshotNames).to.eq(false);
             });
-            it("debug", () => {
-                expect(CONTEXT.config.plugin.debug).to.eq(false);
+            it("overwriteIssueSummary", () => {
+                expect(CONTEXT.config.plugin.overwriteIssueSummary).to.eq(false);
             });
         });
 
@@ -94,7 +97,7 @@ describe("the context configuration", () => {
             it("openSSL", () => {
                 expect(CONTEXT.config.openSSL.rootCAPath).to.eq(undefined);
             });
-            it("uploadFeatures", () => {
+            it("secureOptions", () => {
                 expect(CONTEXT.config.openSSL.secureOptions).to.eq(undefined);
             });
         });
@@ -167,16 +170,27 @@ describe("the context configuration", () => {
         });
 
         describe("plugin", () => {
-            it("overwriteIssueSummary", () => {
+            it("debug", () => {
                 initContext({
                     jira: {
                         projectKey: "PRJ",
                     },
                     plugin: {
-                        overwriteIssueSummary: true,
+                        debug: true,
                     },
                 });
-                expect(CONTEXT.config.plugin.overwriteIssueSummary).to.eq(true);
+                expect(CONTEXT.config.plugin.debug).to.eq(true);
+            });
+            it("enabled", () => {
+                initContext({
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                    plugin: {
+                        enabled: false,
+                    },
+                });
+                expect(CONTEXT.config.plugin.enabled).to.eq(false);
             });
             it("normalizeScreenshotNames", () => {
                 initContext({
@@ -189,16 +203,16 @@ describe("the context configuration", () => {
                 });
                 expect(CONTEXT.config.plugin.normalizeScreenshotNames).to.eq(true);
             });
-            it("debug", () => {
+            it("overwriteIssueSummary", () => {
                 initContext({
                     jira: {
                         projectKey: "PRJ",
                     },
                     plugin: {
-                        debug: true,
+                        overwriteIssueSummary: true,
                     },
                 });
-                expect(CONTEXT.config.plugin.debug).to.eq(true);
+                expect(CONTEXT.config.plugin.overwriteIssueSummary).to.eq(true);
             });
         });
 

--- a/test/src/hooks.ts
+++ b/test/src/hooks.ts
@@ -9,7 +9,7 @@ import {
     ENV_XRAY_CLIENT_SECRET,
 } from "../../src/constants";
 import { CONTEXT, initContext } from "../../src/context";
-import { beforeRunHook } from "../../src/hooks";
+import { afterRunHook, beforeRunHook, filePreprocessorHook } from "../../src/hooks";
 import { stubLogError, stubLogInfo } from "../constants";
 import { expectToExist } from "./helpers";
 
@@ -22,8 +22,6 @@ describe("the before run hook", () => {
     );
 
     beforeEach(() => {
-        // We're not interested in informative log messages here.
-        stubLogInfo();
         initContext({
             jira: {
                 projectKey: "CYP",
@@ -43,6 +41,11 @@ describe("the before run hook", () => {
     });
 
     describe("the error handling", () => {
+        beforeEach(() => {
+            // We're not interested in informative log messages here.
+            stubLogInfo();
+        });
+
         it("should be able to detect unset project keys", async () => {
             expectToExist(details.config.env);
             CONTEXT.config.jira.projectKey = undefined;
@@ -101,12 +104,17 @@ describe("the before run hook", () => {
     it("should not try to parse mismatched feature files", async () => {
         details.specs[0].absolute = "./test/resources/greetings.txt";
         const stubbedError = stubLogError();
+        const stubbedInfo = stubLogInfo();
         await beforeRunHook(details);
         expect(stubbedError).to.not.have.been.called;
+        expect(stubbedInfo).to.have.been.calledWith(
+            'Feature file "./test/resources/greetings.txt" does not have extension ".feature", skipping synchronization.'
+        );
     });
 
     it("should be able to correctly parse feature files", async () => {
         details.specs[0].absolute = "./test/resources/features/taggedCloudExamples.feature";
+        const stubbedInfo = stubLogInfo();
         await beforeRunHook(details);
         expect(CONTEXT.config.cucumber.issues).to.have.property(
             "A tagged scenario with examples",
@@ -123,6 +131,84 @@ describe("the before run hook", () => {
         expect(CONTEXT.config.cucumber.issues).to.have.property(
             "A tagged scenario with examples (example #3)",
             "CYP-123"
+        );
+        // Once during credentials parsing.
+        expect(stubbedInfo).to.have.been.called.with.callCount(1);
+    });
+
+    it("should not do anything if disabled", async () => {
+        const stubbedInfo = stubLogInfo();
+        CONTEXT.config.plugin.enabled = false;
+        await beforeRunHook(details);
+        expect(stubbedInfo).to.have.been.called.with.callCount(1);
+        expect(stubbedInfo).to.have.been.calledWith(
+            "Plugin disabled. Skipping before:run execution."
+        );
+    });
+});
+
+describe("the after run hook", () => {
+    let results: CypressCommandLine.CypressRunResult = JSON.parse(
+        readFileSync("./test/resources/runResult.json", "utf-8")
+    );
+
+    beforeEach(() => {
+        initContext({
+            jira: {
+                projectKey: "CYP",
+            },
+        });
+        results = JSON.parse(readFileSync("./test/resources/runResult.json", "utf-8"));
+    });
+
+    it("should not do anything if disabled", async () => {
+        const stubbedInfo = stubLogInfo();
+        CONTEXT.config.plugin.enabled = false;
+        await afterRunHook(results);
+        expect(stubbedInfo).to.have.been.called.with.callCount(1);
+        expect(stubbedInfo).to.have.been.calledWith(
+            "Plugin disabled. Skipping after:run execution."
+        );
+    });
+});
+
+describe("the file preprocessor hook", () => {
+    const file: Cypress.FileObject = {
+        filePath: "./test/resources/features/taggedCloud.feature",
+        outputPath: "./test/resources/features/taggedCloud.feature",
+        shouldWatch: false,
+        addListener: null,
+        on: null,
+        once: null,
+        removeListener: null,
+        off: null,
+        removeAllListeners: null,
+        setMaxListeners: null,
+        getMaxListeners: null,
+        listeners: null,
+        rawListeners: null,
+        emit: null,
+        listenerCount: null,
+        prependListener: null,
+        prependOnceListener: null,
+        eventNames: null,
+    };
+
+    beforeEach(() => {
+        initContext({
+            jira: {
+                projectKey: "CYP",
+            },
+        });
+    });
+
+    it("should not do anything if disabled", async () => {
+        const stubbedInfo = stubLogInfo();
+        CONTEXT.config.plugin.enabled = false;
+        await filePreprocessorHook(file);
+        expect(stubbedInfo).to.have.been.called.with.callCount(1);
+        expect(stubbedInfo).to.have.been.calledWith(
+            "Plugin disabled. Skipping feature file synchronization."
         );
     });
 });

--- a/test/src/hooks.ts
+++ b/test/src/hooks.ts
@@ -107,9 +107,8 @@ describe("the before run hook", () => {
         const stubbedInfo = stubLogInfo();
         await beforeRunHook(details);
         expect(stubbedError).to.not.have.been.called;
-        expect(stubbedInfo).to.have.been.calledWith(
-            'Feature file "./test/resources/greetings.txt" does not have extension ".feature", skipping synchronization.'
-        );
+        // Once during credentials parsing.
+        expect(stubbedInfo).to.have.been.called.with.callCount(1);
     });
 
     it("should be able to correctly parse feature files", async () => {
@@ -141,9 +140,7 @@ describe("the before run hook", () => {
         CONTEXT.config.plugin.enabled = false;
         await beforeRunHook(details);
         expect(stubbedInfo).to.have.been.called.with.callCount(1);
-        expect(stubbedInfo).to.have.been.calledWith(
-            "Plugin disabled. Skipping before:run execution."
-        );
+        expect(stubbedInfo).to.have.been.calledWith("Plugin disabled. Skipping before:run hook.");
     });
 });
 
@@ -166,9 +163,7 @@ describe("the after run hook", () => {
         CONTEXT.config.plugin.enabled = false;
         await afterRunHook(results);
         expect(stubbedInfo).to.have.been.called.with.callCount(1);
-        expect(stubbedInfo).to.have.been.calledWith(
-            "Plugin disabled. Skipping after:run execution."
-        );
+        expect(stubbedInfo).to.have.been.calledWith("Plugin disabled. Skipping after:run hook.");
     });
 });
 
@@ -208,7 +203,7 @@ describe("the file preprocessor hook", () => {
         await filePreprocessorHook(file);
         expect(stubbedInfo).to.have.been.called.with.callCount(1);
         expect(stubbedInfo).to.have.been.calledWith(
-            "Plugin disabled. Skipping feature file synchronization."
+            'Plugin disabled. Skipping file:preprocessor hook triggered by "./test/resources/features/taggedCloud.feature".'
         );
     });
 });

--- a/test/src/hooks.ts
+++ b/test/src/hooks.ts
@@ -45,6 +45,7 @@ describe("the before run hook", () => {
     describe("the error handling", () => {
         it("should be able to detect unset project keys", async () => {
             expectToExist(details.config.env);
+            CONTEXT.config.jira.projectKey = undefined;
             details.config.env[ENV_JIRA_PROJECT_KEY] = undefined;
             await expect(beforeRunHook(details)).to.eventually.be.rejectedWith(
                 "Xray plugin misconfiguration: Jira project key was not set"

--- a/test/src/util/config.ts
+++ b/test/src/util/config.ts
@@ -43,10 +43,10 @@ describe("the environment variable configuration parser", () => {
 
         it("JIRA_CREATE_TEST_ISSUES", () => {
             env = {
-                JIRA_CREATE_TEST_ISSUES: "true",
+                JIRA_CREATE_TEST_ISSUES: "false",
             };
             parseEnvironmentVariables(env);
-            expect(CONTEXT.config.jira.createTestIssues).to.be.true;
+            expect(CONTEXT.config.jira.createTestIssues).to.be.false;
         });
 
         it("JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION", () => {
@@ -157,10 +157,10 @@ describe("the environment variable configuration parser", () => {
 
         it("XRAY_UPLOAD_SCREENSHOTS", () => {
             env = {
-                XRAY_UPLOAD_SCREENSHOTS: "true",
+                XRAY_UPLOAD_SCREENSHOTS: "false",
             };
             parseEnvironmentVariables(env);
-            expect(CONTEXT.config.xray?.uploadScreenshots).to.be.true;
+            expect(CONTEXT.config.xray?.uploadScreenshots).to.be.false;
         });
     });
 
@@ -183,28 +183,36 @@ describe("the environment variable configuration parser", () => {
 
         it("CUCUMBER_UPLOAD_FEATURES", () => {
             env = {
-                CUCUMBER_UPLOAD_FEATURES: "false",
+                CUCUMBER_UPLOAD_FEATURES: "true",
             };
             parseEnvironmentVariables(env);
-            expect(CONTEXT.config.cucumber?.downloadFeatures).to.be.false;
+            expect(CONTEXT.config.cucumber?.uploadFeatures).to.be.true;
         });
     });
 
     describe("should be able to parse Plugin options", () => {
         it("PLUGIN_DEBUG", () => {
             env = {
-                PLUGIN_DEBUG: "false",
+                PLUGIN_DEBUG: "true",
             };
             parseEnvironmentVariables(env);
-            expect(CONTEXT.config.plugin?.debug).to.be.false;
+            expect(CONTEXT.config.plugin?.debug).to.be.true;
+        });
+
+        it("PLUGIN_ENABLED", () => {
+            env = {
+                PLUGIN_ENABLED: "false",
+            };
+            parseEnvironmentVariables(env);
+            expect(CONTEXT.config.plugin?.enabled).to.be.false;
         });
 
         it("PLUGIN_NORMALIZE_SCREENSHOT_NAMES", () => {
             env = {
-                PLUGIN_NORMALIZE_SCREENSHOT_NAMES: "false",
+                PLUGIN_NORMALIZE_SCREENSHOT_NAMES: "true",
             };
             parseEnvironmentVariables(env);
-            expect(CONTEXT.config.plugin?.normalizeScreenshotNames).to.be.false;
+            expect(CONTEXT.config.plugin?.normalizeScreenshotNames).to.be.true;
         });
 
         it("PLUGIN_OVERWRITE_ISSUE_SUMMARY", () => {


### PR DESCRIPTION
This PR adds the `plugin.enabled` option, which enables or disables the plugin permanently or on the fly using environment variables:
- Configuration:

  ```json
  "plugin": {
    "enabled": false
  }
  ```

- Environment variable:

  ```sh
  PLUGIN_ENABLED="false"
  ```

Related to #88.