### PR TITLE
Invert `xray.uploadResults` check during `after:run` hook

### DIFF
--- a/src/hooks.spec.ts
+++ b/src/hooks.spec.ts
@@ -63,6 +63,16 @@ describe("the after run hook", () => {
             "Pretty messed up"
         );
     });
+
+    it("should skip the results upload if disabled", async () => {
+        const stubbedInfo = stubLogInfo();
+        options.xray.uploadResults = false;
+        await afterRunHook(results, options);
+        expect(stubbedInfo).to.have.been.called.with.callCount(1);
+        expect(stubbedInfo).to.have.been.calledWith(
+            "Skipping results upload: Plugin is configured to not upload test results."
+        );
+    });
 });
 
 describe("the synchronize file hook", () => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -30,7 +30,7 @@ export async function afterRunHook(
         return;
     }
     const runResult = results as CypressCommandLine.CypressRunResult;
-    if (options.xray.uploadResults) {
+    if (!options.xray.uploadResults) {
         logInfo("Skipping results upload: Plugin is configured to not upload test results.");
         return;
     }


### PR DESCRIPTION
Fixes an accidental regression introduced in #102.