### PR TITLE
Add `plugin.logDirectory` option

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -1,13 +1,6 @@
 /// <reference types="cypress" />
 
-import {
-    initJiraClient,
-    initXrayClient,
-    mergeOptions,
-    initOptions as mergeWithDefaults,
-    parseEnvironmentVariables,
-    verifyContext,
-} from "./src/context";
+import { initJiraClient, initOptions, initXrayClient, verifyContext } from "./src/context";
 import { afterRunHook, synchronizeFile } from "./src/hooks";
 import { Requests } from "./src/https/requests";
 import { logInfo } from "./src/logging/logging";
@@ -16,10 +9,8 @@ import { Options, PluginContext } from "./src/types/plugin";
 let context: PluginContext;
 
 export async function configureXrayPlugin(config: Cypress.PluginConfigOptions, options: Options) {
-    const configOptions = mergeWithDefaults(options);
-    const envOptions = parseEnvironmentVariables(config.env);
     context = {
-        internal: mergeOptions(configOptions, envOptions),
+        internal: initOptions(config.env, options),
         cypress: config,
     };
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,11 +1,9 @@
-import { isAxiosError } from "axios";
-import { writeFileSync } from "fs";
 import {
     BasicAuthCredentials,
     JWTCredentials,
     PATCredentials,
 } from "../authentication/credentials";
-import { logError, logInfo } from "../logging/logging";
+import { logInfo } from "../logging/logging";
 import { OneOf } from "../types/util";
 
 /**
@@ -32,29 +30,6 @@ export abstract class Client<
      */
     public getCredentials(): T {
         return this.credentials;
-    }
-
-    /**
-     * Writes an error to a file (e.g. HTTP response errors).
-     *
-     * @param error the error
-     * @param filename the filename to use for the file
-     */
-    protected writeErrorFile(error: unknown, filename: string): void {
-        let errorFileName: string;
-        let errorData: string;
-        if (isAxiosError(error)) {
-            errorFileName = `${filename}.json`;
-            errorData = JSON.stringify({
-                error: error.toJSON(),
-                response: error.response?.data,
-            });
-        } else {
-            errorFileName = `${filename}.log`;
-            errorData = JSON.stringify(error);
-        }
-        writeFileSync(errorFileName, errorData);
-        logError(`Complete error logs have been written to "${errorFileName}"`);
     }
 
     private readonly LOG_RESPONSE_INTERVAL_MS = 10000;

--- a/src/client/jira/jiraClient.ts
+++ b/src/client/jira/jiraClient.ts
@@ -3,7 +3,7 @@ import FormData from "form-data";
 import fs from "fs";
 import { BasicAuthCredentials, HTTPHeader, PATCredentials } from "../../authentication/credentials";
 import { Requests } from "../../https/requests";
-import { logError, logInfo, logSuccess, logWarning } from "../../logging/logging";
+import { logError, logInfo, logSuccess, logWarning, writeErrorFile } from "../../logging/logging";
 import { Attachment } from "../../types/jira/attachments";
 import { Client } from "../client";
 
@@ -85,7 +85,7 @@ export class JiraClient extends Client<BasicAuthCredentials | PATCredentials> {
                 });
         } catch (error: unknown) {
             logError(`Failed to attach files: "${error}"`);
-            this.writeErrorFile(error, "addAttachmentError");
+            writeErrorFile(error, "addAttachmentError");
         }
     }
 }

--- a/src/client/xray/xrayClient.ts
+++ b/src/client/xray/xrayClient.ts
@@ -3,7 +3,7 @@ import {
     JWTCredentials,
     PATCredentials,
 } from "../../authentication/credentials";
-import { logError, logWarning } from "../../logging/logging";
+import { logError, logWarning, writeErrorFile } from "../../logging/logging";
 import { OneOf } from "../../types/util";
 import { ExportCucumberTestsResponse } from "../../types/xray/responses/exportFeature";
 import {
@@ -41,7 +41,7 @@ export abstract class XrayClient<
             return key;
         } catch (error: unknown) {
             logError(`Failed to upload results to Xray: "${error}"`);
-            this.writeErrorFile(error, "importExecutionResultsError");
+            writeErrorFile(error, "importExecutionResultsError");
         }
     }
 
@@ -71,7 +71,7 @@ export abstract class XrayClient<
             return await this.dispatchExportCucumberTestsRequest(keys, filter);
         } catch (error: unknown) {
             logError(`Failed to export cucumber feature files: "${error}"`);
-            this.writeErrorFile(error, "exportCucumberTestsError");
+            writeErrorFile(error, "exportCucumberTestsError");
         }
     }
 
@@ -112,7 +112,7 @@ export abstract class XrayClient<
             );
         } catch (error: unknown) {
             logError(`Failed to import cucumber feature files: "${error}"`);
-            this.writeErrorFile(error, "importCucumberTestsError");
+            writeErrorFile(error, "importCucumberTestsError");
         }
     }
 

--- a/src/client/xray/xrayClientCloud.spec.ts
+++ b/src/client/xray/xrayClientCloud.spec.ts
@@ -15,17 +15,20 @@ describe("the Xray cloud client", () => {
     let options: InternalOptions;
 
     beforeEach(() => {
-        options = initOptions({
-            jira: {
-                projectKey: "CYP",
-            },
-            xray: {
-                testType: "Manual",
-            },
-            cucumber: {
-                featureFileExtension: ".feature",
-            },
-        });
+        options = initOptions(
+            {},
+            {
+                jira: {
+                    projectKey: "CYP",
+                },
+                xray: {
+                    testType: "Manual",
+                },
+                cucumber: {
+                    featureFileExtension: ".feature",
+                },
+            }
+        );
         details = JSON.parse(readFileSync("./test/resources/runResult.json", "utf-8"));
     });
 

--- a/src/client/xray/xrayClientCloud.ts
+++ b/src/client/xray/xrayClientCloud.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import { HTTPHeader, JWTCredentials } from "../../authentication/credentials";
 import { ImportExecutionResultsConverterCloud } from "../../conversion/importExecutionResults/importExecutionResultsConverterCloud";
 import { Requests } from "../../https/requests";
-import { logError, logInfo, logSuccess } from "../../logging/logging";
+import { logError, logInfo, logSuccess, writeErrorFile } from "../../logging/logging";
 import { InternalOptions } from "../../types/plugin";
 import { XrayTestExecutionResultsCloud } from "../../types/xray/importTestExecutionResults";
 import { ExportCucumberTestsResponse } from "../../types/xray/responses/exportFeature";
@@ -43,7 +43,7 @@ export class XrayClientCloud extends XrayClient<JWTCredentials, ImportFeatureRes
             .getAuthenticationHeader(`${XrayClientCloud.URL}/authenticate`)
             .catch((error: unknown) => {
                 logError(`Failed to authenticate: "${error}"`);
-                this.writeErrorFile(error, "authenticationError");
+                writeErrorFile(error, "authenticationError");
                 throw error;
             })
             .then(async (header: HTTPHeader) => {

--- a/src/client/xray/xrayClientServer.ts
+++ b/src/client/xray/xrayClientServer.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import { BasicAuthCredentials, HTTPHeader, PATCredentials } from "../../authentication/credentials";
 import { ImportExecutionResultsConverterServer } from "../../conversion/importExecutionResults/importExecutionResultsConverterServer";
 import { Requests } from "../../https/requests";
-import { logError, logInfo, logSuccess } from "../../logging/logging";
+import { logError, logInfo, logSuccess, writeErrorFile } from "../../logging/logging";
 import { InternalOptions } from "../../types/plugin";
 import { XrayTestExecutionResultsServer } from "../../types/xray/importTestExecutionResults";
 import { ExportCucumberTestsResponse } from "../../types/xray/responses/exportFeature";
@@ -51,7 +51,7 @@ export class XrayClientServer extends XrayClient<
             .getAuthenticationHeader()
             .catch((error: unknown) => {
                 logError(`Failed to authenticate: "${error}"`);
-                this.writeErrorFile(error, "authenticationError");
+                writeErrorFile(error, "authenticationError");
                 throw error;
             })
             .then(async (header: HTTPHeader) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,7 @@ export const ENV_CUCUMBER_UPLOAD_FEATURES = "CUCUMBER_UPLOAD_FEATURES";
 // ============================================================================================== //
 export const ENV_PLUGIN_DEBUG = "PLUGIN_DEBUG";
 export const ENV_PLUGIN_ENABLED = "PLUGIN_ENABLED";
+export const ENV_PLUGIN_LOG_DIRECTORY = "PLUGIN_LOG_DIRECTORY";
 export const ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES = "PLUGIN_NORMALIZE_SCREENSHOT_NAMES";
 export const ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY = "PLUGIN_OVERWRITE_ISSUE_SUMMARY";
 // ============================================================================================== //

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -3,23 +3,20 @@ import { stubLogInfo } from "../test/util";
 import { BasicAuthCredentials, PATCredentials } from "./authentication/credentials";
 import { XrayClientCloud } from "./client/xray/xrayClientCloud";
 import { XrayClientServer } from "./client/xray/xrayClientServer";
-import {
-    initJiraClient,
-    initOptions,
-    initXrayClient,
-    parseEnvironmentVariables,
-    verifyContext as verifyOptions,
-} from "./context";
+import { initJiraClient, initOptions, initXrayClient, verifyContext } from "./context";
 import { InternalOptions } from "./types/plugin";
 
 describe("the plugin context configuration", () => {
-    describe("the configuration variable parser", () => {
+    describe("the option initialization", () => {
         describe("should have certain default values", () => {
-            const options: InternalOptions = initOptions({
-                jira: {
-                    projectKey: "PRJ",
-                },
-            });
+            const options: InternalOptions = initOptions(
+                {},
+                {
+                    jira: {
+                        projectKey: "PRJ",
+                    },
+                }
+            );
             describe("jira", () => {
                 it("attachVideos", () => {
                     expect(options.jira.attachVideos).to.eq(false);
@@ -112,498 +109,741 @@ describe("the plugin context configuration", () => {
         describe("should prefer provided values over default ones", () => {
             describe("jira", () => {
                 it("attachVideos", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                            attachVideos: true,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                                attachVideos: true,
+                            },
+                        }
+                    );
                     expect(options.jira.attachVideos).to.eq(true);
                 });
                 it("createTestIssues", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                            createTestIssues: false,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                                createTestIssues: false,
+                            },
+                        }
+                    );
                     expect(options.jira.createTestIssues).to.eq(false);
                 });
                 it("testExecutionIssueDescription", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                            testExecutionIssueDescription: "hello",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                                testExecutionIssueDescription: "hello",
+                            },
+                        }
+                    );
                     expect(options.jira.testExecutionIssueDescription).to.eq("hello");
                 });
                 it("testExecutionIssueKey", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                            testExecutionIssueKey: "PRJ-123",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                                testExecutionIssueKey: "PRJ-123",
+                            },
+                        }
+                    );
                     expect(options.jira.testExecutionIssueKey).to.eq("PRJ-123");
                 });
                 it("testExecutionIssueSummary", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                            testExecutionIssueSummary: "Test - Login",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                                testExecutionIssueSummary: "Test - Login",
+                            },
+                        }
+                    );
                     expect(options.jira.testExecutionIssueSummary).to.eq("Test - Login");
                 });
                 it("testPlanIssueKey", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                            testPlanIssueKey: "PRJ-456",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                                testPlanIssueKey: "PRJ-456",
+                            },
+                        }
+                    );
                     expect(options.jira.testPlanIssueKey).to.eq("PRJ-456");
                 });
                 it("url", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                            url: "https://example.org",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                                url: "https://example.org",
+                            },
+                        }
+                    );
                     expect(options.jira.url).to.eq("https://example.org");
                 });
             });
 
             describe("plugin", () => {
                 it("debug", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        plugin: {
-                            debug: true,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            plugin: {
+                                debug: true,
+                            },
+                        }
+                    );
                     expect(options.plugin.debug).to.eq(true);
                 });
                 it("enabled", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        plugin: {
-                            enabled: false,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            plugin: {
+                                enabled: false,
+                            },
+                        }
+                    );
                     expect(options.plugin.enabled).to.eq(false);
                 });
                 it("normalizeScreenshotNames", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        plugin: {
-                            normalizeScreenshotNames: true,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            plugin: {
+                                normalizeScreenshotNames: true,
+                            },
+                        }
+                    );
                     expect(options.plugin.normalizeScreenshotNames).to.eq(true);
                 });
                 it("overwriteIssueSummary", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        plugin: {
-                            overwriteIssueSummary: true,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            plugin: {
+                                overwriteIssueSummary: true,
+                            },
+                        }
+                    );
                     expect(options.plugin.overwriteIssueSummary).to.eq(true);
                 });
             });
 
             describe("xray", () => {
                 it("statusFailed", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        xray: {
-                            statusFailed: "BAD",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            xray: {
+                                statusFailed: "BAD",
+                            },
+                        }
+                    );
                     expect(options.xray.statusFailed).to.eq("BAD");
                 });
                 it("statusPassed", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        xray: {
-                            statusPassed: "GOOD",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            xray: {
+                                statusPassed: "GOOD",
+                            },
+                        }
+                    );
                     expect(options.xray.statusPassed).to.eq("GOOD");
                 });
                 it("statusPending", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        xray: {
-                            statusPending: "PENDULUM",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            xray: {
+                                statusPending: "PENDULUM",
+                            },
+                        }
+                    );
                     expect(options.xray.statusPending).to.eq("PENDULUM");
                 });
                 it("statusSkipped", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        xray: {
-                            statusSkipped: "SKIPPING STONE",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            xray: {
+                                statusSkipped: "SKIPPING STONE",
+                            },
+                        }
+                    );
                     expect(options.xray.statusSkipped).to.eq("SKIPPING STONE");
                 });
 
                 describe("steps", () => {
                     it("maxLengthAction", () => {
-                        const options = initOptions({
-                            jira: {
-                                projectKey: "PRJ",
-                            },
-                            xray: {
-                                steps: {
-                                    maxLengthAction: 42,
+                        const options = initOptions(
+                            {},
+                            {
+                                jira: {
+                                    projectKey: "PRJ",
                                 },
-                            },
-                        });
+                                xray: {
+                                    steps: {
+                                        maxLengthAction: 42,
+                                    },
+                                },
+                            }
+                        );
                         expect(options.xray.steps.maxLengthAction).to.eq(42);
                     });
                     it("update", () => {
-                        const options = initOptions({
-                            jira: {
-                                projectKey: "PRJ",
-                            },
-                            xray: {
-                                steps: {
-                                    update: false,
+                        const options = initOptions(
+                            {},
+                            {
+                                jira: {
+                                    projectKey: "PRJ",
                                 },
-                            },
-                        });
+                                xray: {
+                                    steps: {
+                                        update: false,
+                                    },
+                                },
+                            }
+                        );
                         expect(options.xray.steps.update).to.eq(false);
                     });
                 });
                 it("testType", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        xray: {
-                            testType: "Cucumber",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            xray: {
+                                testType: "Cucumber",
+                            },
+                        }
+                    );
                     expect(options.xray.testType).to.eq("Cucumber");
                 });
                 it("uploadResults", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        xray: {
-                            uploadResults: false,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            xray: {
+                                uploadResults: false,
+                            },
+                        }
+                    );
                     expect(options.xray.uploadResults).to.eq(false);
                 });
                 it("uploadScreenshots", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        xray: {
-                            uploadScreenshots: false,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            xray: {
+                                uploadScreenshots: false,
+                            },
+                        }
+                    );
                     expect(options.xray.uploadScreenshots).to.eq(false);
                 });
             });
 
             describe("cucumber", () => {
                 it("downloadFeatures", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        cucumber: {
-                            featureFileExtension: ".feature",
-                            downloadFeatures: true,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            cucumber: {
+                                featureFileExtension: ".feature",
+                                downloadFeatures: true,
+                            },
+                        }
+                    );
                     expect(options.cucumber.downloadFeatures).to.eq(true);
                 });
                 it("uploadFeatures", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        cucumber: {
-                            featureFileExtension: ".feature",
-                            uploadFeatures: true,
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            cucumber: {
+                                featureFileExtension: ".feature",
+                                uploadFeatures: true,
+                            },
+                        }
+                    );
                     expect(options.cucumber.uploadFeatures).to.eq(true);
                 });
             });
 
             describe("openSSL", () => {
                 it("rootCAPath", () => {
-                    const options = initOptions({
-                        jira: {
-                            projectKey: "PRJ",
-                        },
-                        openSSL: {
-                            rootCAPath: "/path/to/cert.pem",
-                        },
-                    });
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            openSSL: {
+                                rootCAPath: "/path/to/cert.pem",
+                            },
+                        }
+                    );
                     expect(options.openSSL.rootCAPath).to.eq("/path/to/cert.pem");
                 });
                 it("secureOptions", () => {
-                    const options = initOptions({
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            openSSL: {
+                                secureOptions: 42,
+                            },
+                        }
+                    );
+                    expect(options.openSSL.secureOptions).to.eq(42);
+                });
+            });
+        });
+        describe("should be able to prefer environment variables over provided values", () => {
+            describe("jira", () => {
+                it("JIRA_PROJECT_KEY", () => {
+                    const env = {
+                        JIRA_PROJECT_KEY: "ABC",
+                    };
+                    const options = initOptions(env, {
                         jira: {
-                            projectKey: "PRJ",
+                            projectKey: "CYP",
+                        },
+                    });
+                    expect(options.jira.projectKey).to.eq("ABC");
+                });
+
+                it("JIRA_ATTACH_VIDEOS", () => {
+                    const env = {
+                        JIRA_ATTACH_VIDEOS: "true",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                            attachVideos: false,
+                        },
+                    });
+                    expect(options.jira.attachVideos).to.be.true;
+                });
+
+                it("JIRA_CREATE_TEST_ISSUES", () => {
+                    const env = {
+                        JIRA_CREATE_TEST_ISSUES: "false",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                            createTestIssues: true,
+                        },
+                    });
+                    expect(options.jira.createTestIssues).to.be.false;
+                });
+
+                it("JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION", () => {
+                    const env = {
+                        JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION: "Good morning",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                            testExecutionIssueDescription: "Goodbye",
+                        },
+                    });
+                    expect(options.jira.testExecutionIssueDescription).to.eq("Good morning");
+                });
+
+                it("JIRA_TEST_EXECUTION_ISSUE_KEY", () => {
+                    const env = {
+                        JIRA_TEST_EXECUTION_ISSUE_KEY: "CYP-123",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                            testExecutionIssueKey: "CYP-789",
+                        },
+                    });
+                    expect(options.jira.testExecutionIssueKey).to.eq("CYP-123");
+                });
+
+                it("JIRA_TEST_EXECUTION_ISSUE_SUMMARY", () => {
+                    const env = {
+                        JIRA_TEST_EXECUTION_ISSUE_SUMMARY: "Some test case",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                            testExecutionIssueSummary: "Summarini",
+                        },
+                    });
+                    expect(options.jira.testExecutionIssueSummary).to.eq("Some test case");
+                });
+
+                it("JIRA_TEST_PLAN_ISSUE_KEY", () => {
+                    const env = {
+                        JIRA_TEST_PLAN_ISSUE_KEY: "CYP-456",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                            testPlanIssueKey: "CYP-123",
+                        },
+                    });
+                    expect(options.jira.testPlanIssueKey).to.eq("CYP-456");
+                });
+
+                it("JIRA_URL", () => {
+                    const env = {
+                        JIRA_URL: "https://example.org",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                            url: "https://some.domain.org",
+                        },
+                    });
+                    expect(options.jira.url).to.eq("https://example.org");
+                });
+            });
+            describe("xray", () => {
+                it("XRAY_STATUS_FAILED", () => {
+                    const env = {
+                        XRAY_STATUS_FAILED: "no",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        xray: {
+                            statusFailed: "ERROR",
+                        },
+                    });
+                    expect(options.xray?.statusFailed).to.eq("no");
+                });
+
+                it("XRAY_STATUS_PASSED", () => {
+                    const env = {
+                        XRAY_STATUS_PASSED: "ok",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        xray: {
+                            statusPassed: "FLYBY",
+                        },
+                    });
+                    expect(options.xray?.statusPassed).to.eq("ok");
+                });
+
+                it("XRAY_STATUS_PENDING", () => {
+                    const env = {
+                        XRAY_STATUS_PENDING: "pendulum",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        xray: {
+                            statusPending: "PENCIL",
+                        },
+                    });
+                    expect(options.xray?.statusPending).to.eq("pendulum");
+                });
+
+                it("XRAY_STATUS_SKIPPED", () => {
+                    const env = {
+                        XRAY_STATUS_SKIPPED: "ski-ba-bop-ba-dop-bop",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        xray: {
+                            statusSkipped: "HOP",
+                        },
+                    });
+                    expect(options.xray?.statusSkipped).to.eq("ski-ba-bop-ba-dop-bop");
+                });
+
+                it("XRAY_STEPS_MAX_LENGTH_ACTION", () => {
+                    const env = {
+                        XRAY_STEPS_MAX_LENGTH_ACTION: "12345",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        xray: {
+                            steps: {
+                                maxLengthAction: 500,
+                            },
+                        },
+                    });
+                    expect(options.xray?.steps?.maxLengthAction).to.eq(12345);
+                });
+
+                it("XRAY_STEPS_UPDATE", () => {
+                    const env = {
+                        XRAY_STEPS_UPDATE: "false",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        xray: {
+                            steps: {
+                                update: true,
+                            },
+                        },
+                    });
+                    expect(options.xray?.steps?.update).to.be.false;
+                });
+
+                it("XRAY_TEST_TYPE", () => {
+                    const env = {
+                        XRAY_TEST_TYPE: "Automated",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        xray: {
+                            testType: "Gherkin",
+                        },
+                    });
+                    expect(options.xray?.testType).to.eq("Automated");
+                });
+
+                it("XRAY_UPLOAD_RESULTS", () => {
+                    const env = {
+                        XRAY_UPLOAD_RESULTS: "false",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        xray: {
+                            uploadResults: true,
+                        },
+                    });
+                    expect(options.xray?.uploadResults).to.be.false;
+                });
+
+                it("XRAY_UPLOAD_SCREENSHOTS", () => {
+                    const env = {
+                        XRAY_UPLOAD_SCREENSHOTS: "false",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        xray: {
+                            uploadScreenshots: true,
+                        },
+                    });
+                    expect(options.xray?.uploadScreenshots).to.be.false;
+                });
+            });
+            describe("cucumber", () => {
+                it("CUCUMBER_FEATURE_FILE_EXTENSION", () => {
+                    const env = {
+                        CUCUMBER_FEATURE_FILE_EXTENSION: ".feature.file",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        cucumber: {
+                            featureFileExtension: ".feature",
+                        },
+                    });
+                    expect(options.cucumber.featureFileExtension).to.eq(".feature.file");
+                });
+
+                it("CUCUMBER_DOWNLOAD_FEATURES", () => {
+                    const env = {
+                        CUCUMBER_DOWNLOAD_FEATURES: "true",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        cucumber: {
+                            featureFileExtension: ".feature",
+                            downloadFeatures: false,
+                        },
+                    });
+                    expect(options.cucumber?.downloadFeatures).to.be.true;
+                });
+
+                it("CUCUMBER_UPLOAD_FEATURES", () => {
+                    const env = {
+                        CUCUMBER_UPLOAD_FEATURES: "true",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        cucumber: {
+                            featureFileExtension: ".feature",
+                            uploadFeatures: false,
+                        },
+                    });
+                    expect(options.cucumber?.uploadFeatures).to.be.true;
+                });
+            });
+            describe("plugin", () => {
+                it("PLUGIN_DEBUG", () => {
+                    const env = {
+                        PLUGIN_DEBUG: "true",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        plugin: {
+                            debug: false,
+                        },
+                    });
+                    expect(options.plugin?.debug).to.be.true;
+                });
+
+                it("PLUGIN_ENABLED", () => {
+                    const env = {
+                        PLUGIN_ENABLED: "false",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        plugin: {
+                            enabled: true,
+                        },
+                    });
+                    expect(options.plugin?.enabled).to.be.false;
+                });
+
+                it("PLUGIN_NORMALIZE_SCREENSHOT_NAMES", () => {
+                    const env = {
+                        PLUGIN_NORMALIZE_SCREENSHOT_NAMES: "true",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        plugin: {
+                            normalizeScreenshotNames: false,
+                        },
+                    });
+                    expect(options.plugin?.normalizeScreenshotNames).to.be.true;
+                });
+
+                it("PLUGIN_OVERWRITE_ISSUE_SUMMARY", () => {
+                    const env = {
+                        PLUGIN_OVERWRITE_ISSUE_SUMMARY: "true",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        plugin: {
+                            overwriteIssueSummary: false,
+                        },
+                    });
+                    expect(options.plugin?.overwriteIssueSummary).to.be.true;
+                });
+            });
+            describe("openSSL", () => {
+                it("OPENSSL_ROOT_CA_PATH ", () => {
+                    const env = {
+                        OPENSSL_ROOT_CA_PATH: "/home/ssl/ca.pem",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        openSSL: {
+                            rootCAPath: "/a/b/c.pem",
+                        },
+                    });
+                    expect(options.openSSL?.rootCAPath).to.eq("/home/ssl/ca.pem");
+                });
+
+                it("OPENSSL_SECURE_OPTIONS ", () => {
+                    const env = {
+                        OPENSSL_SECURE_OPTIONS: 415,
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
                         },
                         openSSL: {
                             secureOptions: 42,
                         },
                     });
-                    expect(options.openSSL.secureOptions).to.eq(42);
+                    expect(options.openSSL?.secureOptions).to.eq(415);
                 });
-            });
-        });
-    });
-    describe("the environment variable parser", () => {
-        describe("should be able to parse Jira options", () => {
-            it("JIRA_PROJECT_KEY", () => {
-                const env = {
-                    JIRA_PROJECT_KEY: "ABC",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.jira.projectKey).to.eq("ABC");
-            });
-
-            it("JIRA_ATTACH_VIDEOS", () => {
-                const env = {
-                    JIRA_ATTACH_VIDEOS: "true",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.jira.attachVideos).to.be.true;
-            });
-
-            it("JIRA_CREATE_TEST_ISSUES", () => {
-                const env = {
-                    JIRA_CREATE_TEST_ISSUES: "false",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.jira.createTestIssues).to.be.false;
-            });
-
-            it("JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION", () => {
-                const env = {
-                    JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION: "Good morning",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.jira.testExecutionIssueDescription).to.eq("Good morning");
-            });
-
-            it("JIRA_TEST_EXECUTION_ISSUE_KEY", () => {
-                const env = {
-                    JIRA_TEST_EXECUTION_ISSUE_KEY: "CYP-123",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.jira.testExecutionIssueKey).to.eq("CYP-123");
-            });
-
-            it("JIRA_TEST_EXECUTION_ISSUE_SUMMARY", () => {
-                const env = {
-                    JIRA_TEST_EXECUTION_ISSUE_SUMMARY: "Some test case",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.jira.testExecutionIssueSummary).to.eq("Some test case");
-            });
-
-            it("JIRA_TEST_PLAN_ISSUE_KEY", () => {
-                const env = {
-                    JIRA_TEST_PLAN_ISSUE_KEY: "CYP-456",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.jira.testPlanIssueKey).to.eq("CYP-456");
-            });
-
-            it("JIRA_URL", () => {
-                const env = {
-                    JIRA_URL: "https://example.org",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.jira.url).to.eq("https://example.org");
-            });
-        });
-        describe("should be able to parse Xray options", () => {
-            it("XRAY_STATUS_FAILED", () => {
-                const env = {
-                    XRAY_STATUS_FAILED: "no",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.xray?.statusFailed).to.eq("no");
-            });
-
-            it("XRAY_STATUS_PASSED", () => {
-                const env = {
-                    XRAY_STATUS_PASSED: "ok",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.xray?.statusPassed).to.eq("ok");
-            });
-
-            it("XRAY_STATUS_PENDING", () => {
-                const env = {
-                    XRAY_STATUS_PENDING: "pendulum",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.xray?.statusPending).to.eq("pendulum");
-            });
-
-            it("XRAY_STATUS_SKIPPED", () => {
-                const env = {
-                    XRAY_STATUS_SKIPPED: "ski-ba-bop-ba-dop-bop",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.xray?.statusSkipped).to.eq("ski-ba-bop-ba-dop-bop");
-            });
-
-            it("XRAY_STEPS_MAX_LENGTH_ACTION", () => {
-                const env = {
-                    XRAY_STEPS_MAX_LENGTH_ACTION: "12345",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.xray?.steps?.maxLengthAction).to.eq(12345);
-            });
-
-            it("XRAY_STEPS_UPDATE", () => {
-                const env = {
-                    XRAY_STEPS_UPDATE: "false",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.xray?.steps?.update).to.be.false;
-            });
-
-            it("XRAY_TEST_TYPE", () => {
-                const env = {
-                    XRAY_TEST_TYPE: "Automated",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.xray?.testType).to.eq("Automated");
-            });
-
-            it("XRAY_UPLOAD_RESULTS", () => {
-                const env = {
-                    XRAY_UPLOAD_RESULTS: "false",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.xray?.uploadResults).to.be.false;
-            });
-
-            it("XRAY_UPLOAD_SCREENSHOTS", () => {
-                const env = {
-                    XRAY_UPLOAD_SCREENSHOTS: "false",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.xray?.uploadScreenshots).to.be.false;
-            });
-        });
-        describe("should be able to parse Cucumber options", () => {
-            it("CUCUMBER_FEATURE_FILE_EXTENSION", () => {
-                const env = {
-                    CUCUMBER_FEATURE_FILE_EXTENSION: ".feature.file",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.cucumber.featureFileExtension).to.eq(".feature.file");
-            });
-
-            it("CUCUMBER_DOWNLOAD_FEATURES", () => {
-                const env = {
-                    CUCUMBER_DOWNLOAD_FEATURES: "true",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.cucumber?.downloadFeatures).to.be.true;
-            });
-
-            it("CUCUMBER_UPLOAD_FEATURES", () => {
-                const env = {
-                    CUCUMBER_UPLOAD_FEATURES: "true",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.cucumber?.uploadFeatures).to.be.true;
-            });
-        });
-        describe("should be able to parse Plugin options", () => {
-            it("PLUGIN_DEBUG", () => {
-                const env = {
-                    PLUGIN_DEBUG: "true",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.plugin?.debug).to.be.true;
-            });
-
-            it("PLUGIN_ENABLED", () => {
-                const env = {
-                    PLUGIN_ENABLED: "false",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.plugin?.enabled).to.be.false;
-            });
-
-            it("PLUGIN_NORMALIZE_SCREENSHOT_NAMES", () => {
-                const env = {
-                    PLUGIN_NORMALIZE_SCREENSHOT_NAMES: "true",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.plugin?.normalizeScreenshotNames).to.be.true;
-            });
-
-            it("PLUGIN_OVERWRITE_ISSUE_SUMMARY", () => {
-                const env = {
-                    PLUGIN_OVERWRITE_ISSUE_SUMMARY: "true",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.plugin?.overwriteIssueSummary).to.be.true;
-            });
-        });
-        describe("should be able to parse OpenSSL options", () => {
-            it("OPENSSL_ROOT_CA_PATH ", () => {
-                const env = {
-                    OPENSSL_ROOT_CA_PATH: "/home/ssl/ca.pem",
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.openSSL?.rootCAPath).to.eq("/home/ssl/ca.pem");
-            });
-
-            it("OPENSSL_SECURE_OPTIONS ", () => {
-                const env = {
-                    OPENSSL_SECURE_OPTIONS: 415,
-                };
-                const options = parseEnvironmentVariables(env);
-                expect(options.openSSL?.secureOptions).to.eq(415);
             });
         });
     });
     describe("the options verifier", () => {
         it("should be able to detect unset project keys", async () => {
             expect(() =>
-                verifyOptions({
+                verifyContext({
                     jira: {
                         projectKey: undefined,
                     },
@@ -612,7 +852,7 @@ describe("the plugin context configuration", () => {
         });
         it("should be able to detect mismatched test execution issue keys", async () => {
             expect(() =>
-                verifyOptions({
+                verifyContext({
                     jira: {
                         projectKey: "CYP",
                         testExecutionIssueKey: "ABC-123",
@@ -624,7 +864,7 @@ describe("the plugin context configuration", () => {
         });
         it("should be able to detect mismatched test plan issue keys", async () => {
             expect(() =>
-                verifyOptions({
+                verifyContext({
                     jira: {
                         projectKey: "CYP",
                         testPlanIssueKey: "ABC-456",
@@ -636,7 +876,7 @@ describe("the plugin context configuration", () => {
         });
         it("should not allow step lengths of length zero", async () => {
             expect(() =>
-                verifyOptions({
+                verifyContext({
                     jira: {
                         projectKey: "CYP",
                     },
@@ -652,7 +892,7 @@ describe("the plugin context configuration", () => {
         });
         it("should not allow negative step action lengths", async () => {
             expect(() =>
-                verifyOptions({
+                verifyContext({
                     jira: {
                         projectKey: "CYP",
                     },
@@ -670,12 +910,15 @@ describe("the plugin context configuration", () => {
     describe("the Jira client instantiation", () => {
         let options: InternalOptions;
         beforeEach(() => {
-            options = initOptions({
-                jira: {
-                    projectKey: "CYP",
-                    url: "https://example.org",
-                },
-            });
+            options = initOptions(
+                {},
+                {
+                    jira: {
+                        projectKey: "CYP",
+                        url: "https://example.org",
+                    },
+                }
+            );
             // Make Jira client instantiation mandatory.
             options.jira.attachVideos = true;
         });
@@ -760,11 +1003,14 @@ describe("the plugin context configuration", () => {
     describe("the Xray client instantiation", () => {
         let options: InternalOptions;
         beforeEach(() => {
-            options = initOptions({
-                jira: {
-                    projectKey: "CYP",
-                },
-            });
+            options = initOptions(
+                {},
+                {
+                    jira: {
+                        projectKey: "CYP",
+                    },
+                }
+            );
         });
 
         it("should be able to detect cloud credentials", () => {

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -48,6 +48,9 @@ describe("the plugin context configuration", () => {
                 it("enabled", () => {
                     expect(options.plugin.enabled).to.eq(true);
                 });
+                it("logDirectory", () => {
+                    expect(options.plugin.logDirectory).to.eq("logs");
+                });
                 it("normalizeScreenshotNames", () => {
                     expect(options.plugin.normalizeScreenshotNames).to.eq(false);
                 });
@@ -222,6 +225,20 @@ describe("the plugin context configuration", () => {
                         }
                     );
                     expect(options.plugin.enabled).to.eq(false);
+                });
+                it("logDirectory", () => {
+                    const options = initOptions(
+                        {},
+                        {
+                            jira: {
+                                projectKey: "PRJ",
+                            },
+                            plugin: {
+                                logDirectory: "./logs/",
+                            },
+                        }
+                    );
+                    expect(options.plugin.logDirectory).to.eq("./logs/");
                 });
                 it("normalizeScreenshotNames", () => {
                     const options = initOptions(
@@ -775,6 +792,21 @@ describe("the plugin context configuration", () => {
                         },
                     });
                     expect(options.plugin?.enabled).to.be.false;
+                });
+
+                it("PLUGIN_LOG_DIRECTORY", () => {
+                    const env = {
+                        PLUGIN_LOG_DIRECTORY: "/home/logs/cypress-xray-plugin",
+                    };
+                    const options = initOptions(env, {
+                        jira: {
+                            projectKey: "CYP",
+                        },
+                        plugin: {
+                            logDirectory: "./logging/subdirectory",
+                        },
+                    });
+                    expect(options.plugin?.logDirectory).to.eq("/home/logs/cypress-xray-plugin");
                 });
 
                 it("PLUGIN_NORMALIZE_SCREENSHOT_NAMES", () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -21,6 +21,7 @@ import {
     ENV_OPENSSL_SECURE_OPTIONS,
     ENV_PLUGIN_DEBUG,
     ENV_PLUGIN_ENABLED,
+    ENV_PLUGIN_LOG_DIRECTORY,
     ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES,
     ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY,
     ENV_XRAY_CLIENT_ID,
@@ -40,160 +41,94 @@ import { InternalOptions, Options, XrayStepOptions } from "./types/plugin";
 import { OneOf } from "./types/util";
 import { asBoolean, asInt, asString, parse } from "./util/parsing";
 
-export function initOptions(options: Options): InternalOptions {
-    // Set some default values for constant options.
+export function initOptions(env: Cypress.ObjectLike, options: Options): InternalOptions {
     return {
         jira: {
-            attachVideos: options.jira?.attachVideos ?? false,
-            createTestIssues: options.jira?.createTestIssues ?? true,
-            projectKey: options.jira?.projectKey,
-            testExecutionIssueDescription: options.jira?.testExecutionIssueDescription,
-            testExecutionIssueKey: options.jira?.testExecutionIssueKey,
-            testExecutionIssueSummary: options.jira?.testExecutionIssueSummary,
-            testPlanIssueKey: options.jira?.testPlanIssueKey,
-            url: options.jira?.url,
-        },
-        plugin: {
-            debug: options.plugin?.debug ?? false,
-            enabled: options.plugin?.enabled ?? true,
-            normalizeScreenshotNames: options.plugin?.normalizeScreenshotNames ?? false,
-            overwriteIssueSummary: options.plugin?.overwriteIssueSummary ?? false,
-        },
-        xray: {
-            statusFailed: options.xray?.statusFailed,
-            statusPassed: options.xray?.statusPassed,
-            statusPending: options.xray?.statusPending,
-            statusSkipped: options.xray?.statusSkipped,
-            steps: {
-                maxLengthAction: options.xray?.steps?.maxLengthAction ?? 8000,
-                update: options.xray?.steps?.update ?? true,
-            },
-            testType: options.xray?.testType ?? "Manual",
-            uploadResults: options.xray?.uploadResults ?? true,
-            uploadScreenshots: options.xray?.uploadScreenshots ?? true,
-        },
-        cucumber: {
-            featureFileExtension: options.cucumber?.featureFileExtension,
-            downloadFeatures: options.cucumber?.downloadFeatures ?? false,
-            issues: {},
-            uploadFeatures: options.cucumber?.uploadFeatures ?? false,
-        },
-        openSSL: {
-            rootCAPath: options.openSSL?.rootCAPath,
-            secureOptions: options.openSSL?.secureOptions,
-        },
-    };
-}
-
-export function parseEnvironmentVariables(env: Cypress.ObjectLike): InternalOptions {
-    return {
-        jira: {
-            projectKey: parse(env, ENV_JIRA_PROJECT_KEY, asString),
-            attachVideos: parse(env, ENV_JIRA_ATTACH_VIDEOS, asBoolean),
-            createTestIssues: parse(env, ENV_JIRA_CREATE_TEST_ISSUES, asBoolean),
-            testExecutionIssueDescription: parse(
-                env,
-                ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION,
-                asString
-            ),
-            testExecutionIssueKey: parse(env, ENV_JIRA_TEST_EXECUTION_ISSUE_KEY, asString),
-            testExecutionIssueSummary: parse(env, ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY, asString),
-            testPlanIssueKey: parse(env, ENV_JIRA_TEST_PLAN_ISSUE_KEY, asString),
-            url: parse(env, ENV_JIRA_URL, asString),
-        },
-        xray: {
-            statusFailed: parse(env, ENV_XRAY_STATUS_FAILED, asString),
-            statusPassed: parse(env, ENV_XRAY_STATUS_PASSED, asString),
-            statusPending: parse(env, ENV_XRAY_STATUS_PENDING, asString),
-            statusSkipped: parse(env, ENV_XRAY_STATUS_SKIPPED, asString),
-            steps: {
-                maxLengthAction: parse(env, ENV_XRAY_STEPS_MAX_LENGTH_ACTION, asInt),
-                update: parse(env, ENV_XRAY_STEPS_UPDATE, asBoolean),
-            },
-            testType: parse(env, ENV_XRAY_TEST_TYPE, asString),
-            uploadResults: parse(env, ENV_XRAY_UPLOAD_RESULTS, asBoolean),
-            uploadScreenshots: parse(env, ENV_XRAY_UPLOAD_SCREENSHOTS, asBoolean),
-        },
-        cucumber: {
-            featureFileExtension: parse(env, ENV_CUCUMBER_FEATURE_FILE_EXTENSION, asString),
-            downloadFeatures: parse(env, ENV_CUCUMBER_DOWNLOAD_FEATURES, asBoolean),
-            issues: {},
-            uploadFeatures: parse(env, ENV_CUCUMBER_UPLOAD_FEATURES, asBoolean),
-        },
-        plugin: {
-            enabled: parse(env, ENV_PLUGIN_ENABLED, asBoolean),
-            debug: parse(env, ENV_PLUGIN_DEBUG, asBoolean),
-            normalizeScreenshotNames: parse(env, ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES, asBoolean),
-            overwriteIssueSummary: parse(env, ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY, asBoolean),
-        },
-        openSSL: {
-            rootCAPath: parse(env, ENV_OPENSSL_ROOT_CA_PATH, asString),
-            secureOptions: parse(env, ENV_OPENSSL_SECURE_OPTIONS, asInt),
-        },
-    };
-}
-
-export function mergeOptions(
-    configOptions: InternalOptions,
-    envOptions: InternalOptions
-): InternalOptions {
-    return {
-        jira: {
-            projectKey: envOptions.jira.projectKey ?? configOptions.jira.projectKey,
-            attachVideos: envOptions.jira.attachVideos ?? configOptions.jira.attachVideos,
+            attachVideos:
+                parse(env, ENV_JIRA_ATTACH_VIDEOS, asBoolean) ?? options.jira.attachVideos ?? false,
             createTestIssues:
-                envOptions.jira.createTestIssues ?? configOptions.jira.createTestIssues,
+                parse(env, ENV_JIRA_CREATE_TEST_ISSUES, asBoolean) ??
+                options.jira.createTestIssues ??
+                true,
+            projectKey: parse(env, ENV_JIRA_PROJECT_KEY, asString) ?? options.jira.projectKey,
             testExecutionIssueDescription:
-                envOptions.jira.testExecutionIssueDescription ??
-                configOptions.jira.testExecutionIssueDescription,
+                parse(env, ENV_JIRA_TEST_EXECUTION_ISSUE_DESCRIPTION, asString) ??
+                options.jira.testExecutionIssueDescription,
             testExecutionIssueKey:
-                envOptions.jira.testExecutionIssueKey ?? configOptions.jira.testExecutionIssueKey,
+                parse(env, ENV_JIRA_TEST_EXECUTION_ISSUE_KEY, asString) ??
+                options.jira.testExecutionIssueKey,
             testExecutionIssueSummary:
-                envOptions.jira.testExecutionIssueSummary ??
-                configOptions.jira.testExecutionIssueSummary,
+                parse(env, ENV_JIRA_TEST_EXECUTION_ISSUE_SUMMARY, asString) ??
+                options.jira.testExecutionIssueSummary,
             testPlanIssueKey:
-                envOptions.jira.testPlanIssueKey ?? configOptions.jira.testPlanIssueKey,
-            url: envOptions.jira.url ?? configOptions.jira.url,
+                parse(env, ENV_JIRA_TEST_PLAN_ISSUE_KEY, asString) ?? options.jira.testPlanIssueKey,
+            url: parse(env, ENV_JIRA_URL, asString) ?? options.jira.url,
+        },
+        plugin: {
+            debug: parse(env, ENV_PLUGIN_DEBUG, asBoolean) ?? options.plugin?.debug ?? false,
+            enabled: parse(env, ENV_PLUGIN_ENABLED, asBoolean) ?? options.plugin?.enabled ?? true,
+            logDirectory:
+                parse(env, ENV_PLUGIN_LOG_DIRECTORY, asString) ??
+                options.plugin?.logDirectory ??
+                ".",
+            normalizeScreenshotNames:
+                parse(env, ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES, asBoolean) ??
+                options.plugin?.normalizeScreenshotNames ??
+                false,
+            overwriteIssueSummary:
+                parse(env, ENV_PLUGIN_OVERWRITE_ISSUE_SUMMARY, asBoolean) ??
+                options.plugin?.overwriteIssueSummary ??
+                false,
         },
         xray: {
-            statusFailed: envOptions.xray.statusFailed ?? configOptions.xray.statusFailed,
-            statusPassed: envOptions.xray.statusPassed ?? configOptions.xray.statusPassed,
-            statusPending: envOptions.xray.statusPending ?? configOptions.xray.statusPending,
-            statusSkipped: envOptions.xray.statusSkipped ?? configOptions.xray.statusSkipped,
+            statusFailed:
+                parse(env, ENV_XRAY_STATUS_FAILED, asString) ?? options.xray?.statusFailed,
+            statusPassed:
+                parse(env, ENV_XRAY_STATUS_PASSED, asString) ?? options.xray?.statusPassed,
+            statusPending:
+                parse(env, ENV_XRAY_STATUS_PENDING, asString) ?? options.xray?.statusPending,
+            statusSkipped:
+                parse(env, ENV_XRAY_STATUS_SKIPPED, asString) ?? options.xray?.statusSkipped,
             steps: {
                 maxLengthAction:
-                    envOptions.xray.steps.maxLengthAction ??
-                    configOptions.xray.steps.maxLengthAction,
-                update: envOptions.xray.steps.update ?? configOptions.xray.steps.update,
+                    parse(env, ENV_XRAY_STEPS_MAX_LENGTH_ACTION, asInt) ??
+                    options.xray?.steps?.maxLengthAction ??
+                    8000,
+                update:
+                    parse(env, ENV_XRAY_STEPS_UPDATE, asBoolean) ??
+                    options.xray?.steps?.update ??
+                    true,
             },
-            testType: envOptions.xray.testType ?? configOptions.xray.testType,
-            uploadResults: envOptions.xray.uploadResults ?? configOptions.xray.uploadResults,
+            testType:
+                parse(env, ENV_XRAY_TEST_TYPE, asString) ?? options.xray?.testType ?? "Manual",
+            uploadResults:
+                parse(env, ENV_XRAY_UPLOAD_RESULTS, asBoolean) ??
+                options.xray?.uploadResults ??
+                true,
             uploadScreenshots:
-                envOptions.xray.uploadScreenshots ?? configOptions.xray.uploadScreenshots,
+                parse(env, ENV_XRAY_UPLOAD_SCREENSHOTS, asBoolean) ??
+                options.xray?.uploadScreenshots ??
+                true,
         },
         cucumber: {
             featureFileExtension:
-                envOptions.cucumber.featureFileExtension ??
-                configOptions.cucumber.featureFileExtension,
+                parse(env, ENV_CUCUMBER_FEATURE_FILE_EXTENSION, asString) ??
+                options.cucumber?.featureFileExtension,
             downloadFeatures:
-                envOptions.cucumber.downloadFeatures ?? configOptions.cucumber.downloadFeatures,
-            issues: envOptions.cucumber.issues ?? configOptions.cucumber.issues,
+                parse(env, ENV_CUCUMBER_DOWNLOAD_FEATURES, asBoolean) ??
+                options.cucumber?.downloadFeatures ??
+                false,
+            issues: {},
             uploadFeatures:
-                envOptions.cucumber.uploadFeatures ?? configOptions.cucumber.uploadFeatures,
-        },
-        plugin: {
-            enabled: envOptions.plugin.enabled ?? configOptions.plugin.enabled,
-            debug: envOptions.plugin.debug ?? configOptions.plugin.debug,
-            normalizeScreenshotNames:
-                envOptions.plugin.normalizeScreenshotNames ??
-                configOptions.plugin.normalizeScreenshotNames,
-            overwriteIssueSummary:
-                envOptions.plugin.overwriteIssueSummary ??
-                configOptions.plugin.overwriteIssueSummary,
+                parse(env, ENV_CUCUMBER_UPLOAD_FEATURES, asBoolean) ??
+                options.cucumber?.uploadFeatures ??
+                false,
         },
         openSSL: {
-            rootCAPath: envOptions.openSSL.rootCAPath ?? configOptions.openSSL.rootCAPath,
-            secureOptions: envOptions.openSSL.secureOptions ?? configOptions.openSSL.secureOptions,
+            rootCAPath:
+                parse(env, ENV_OPENSSL_ROOT_CA_PATH, asString) ?? options.openSSL?.rootCAPath,
+            secureOptions:
+                parse(env, ENV_OPENSSL_SECURE_OPTIONS, asInt) ?? options.openSSL?.secureOptions,
         },
     };
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -70,7 +70,7 @@ export function initOptions(env: Cypress.ObjectLike, options: Options): Internal
             logDirectory:
                 parse(env, ENV_PLUGIN_LOG_DIRECTORY, asString) ??
                 options.plugin?.logDirectory ??
-                ".",
+                "logs",
             normalizeScreenshotNames:
                 parse(env, ENV_PLUGIN_NORMALIZE_SCREENSHOT_NAMES, asBoolean) ??
                 options.plugin?.normalizeScreenshotNames ??

--- a/src/conversion/importExecutionResults/importExecutionResultsConverter.spec.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverter.spec.ts
@@ -11,18 +11,21 @@ import { ImportExecutionResultsConverterCloud } from "./importExecutionResultsCo
 describe("the import execution results converter", () => {
     let options: InternalOptions;
     beforeEach(() => {
-        options = initOptions({
-            jira: {
-                projectKey: "CYP",
-            },
-            xray: {
-                testType: "Manual",
-                uploadResults: true,
-            },
-            cucumber: {
-                featureFileExtension: ".feature",
-            },
-        });
+        options = initOptions(
+            {},
+            {
+                jira: {
+                    projectKey: "CYP",
+                },
+                xray: {
+                    testType: "Manual",
+                    uploadResults: true,
+                },
+                cucumber: {
+                    featureFileExtension: ".feature",
+                },
+            }
+        );
     });
 
     it("should be able to convert test results into Xray JSON", () => {

--- a/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.spec.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterCloud.spec.ts
@@ -10,18 +10,21 @@ import { ImportExecutionResultsConverterCloud } from "./importExecutionResultsCo
 describe("the import execution results converter (cloud)", () => {
     let options: InternalOptions;
     beforeEach(() => {
-        options = initOptions({
-            jira: {
-                projectKey: "CYP",
-            },
-            xray: {
-                testType: "Manual",
-                uploadResults: true,
-            },
-            cucumber: {
-                featureFileExtension: ".feature",
-            },
-        });
+        options = initOptions(
+            {},
+            {
+                jira: {
+                    projectKey: "CYP",
+                },
+                xray: {
+                    testType: "Manual",
+                    uploadResults: true,
+                },
+                cucumber: {
+                    featureFileExtension: ".feature",
+                },
+            }
+        );
     });
 
     it("should upload screenshots by default", () => {

--- a/src/conversion/importExecutionResults/importExecutionResultsConverterServer.spec.ts
+++ b/src/conversion/importExecutionResults/importExecutionResultsConverterServer.spec.ts
@@ -10,18 +10,21 @@ describe("the import execution results converter (server)", () => {
     let options: InternalOptions;
 
     beforeEach(() => {
-        options = initOptions({
-            jira: {
-                projectKey: "CYP",
-            },
-            xray: {
-                testType: "Manual",
-                uploadResults: true,
-            },
-            cucumber: {
-                featureFileExtension: ".feature",
-            },
-        });
+        options = initOptions(
+            {},
+            {
+                jira: {
+                    projectKey: "CYP",
+                },
+                xray: {
+                    testType: "Manual",
+                    uploadResults: true,
+                },
+                cucumber: {
+                    featureFileExtension: ".feature",
+                },
+            }
+        );
     });
 
     it("should upload screenshots by default", () => {

--- a/src/hooks.spec.ts
+++ b/src/hooks.spec.ts
@@ -22,11 +22,14 @@ describe("the after run hook", () => {
 
     beforeEach(() => {
         results = JSON.parse(readFileSync("./test/resources/runResult.json", "utf-8"));
-        options = initOptions({
-            jira: {
-                projectKey: "CYP",
-            },
-        });
+        options = initOptions(
+            {},
+            {
+                jira: {
+                    projectKey: "CYP",
+                },
+            }
+        );
     });
 
     it("should display errors if the plugin was not configured", async () => {
@@ -104,14 +107,17 @@ describe("the synchronize file hook", () => {
     let options: InternalOptions;
 
     beforeEach(() => {
-        options = initOptions({
-            jira: {
-                projectKey: "CYP",
-            },
-            cucumber: {
-                featureFileExtension: ".feature",
-            },
-        });
+        options = initOptions(
+            {},
+            {
+                jira: {
+                    projectKey: "CYP",
+                },
+                cucumber: {
+                    featureFileExtension: ".feature",
+                },
+            }
+        );
         details = JSON.parse(readFileSync("./test/resources/beforeRun.json", "utf-8"));
         // Set up cloud credentials for convenience purposes.
         details.config.env = {};

--- a/src/https/requests.ts
+++ b/src/https/requests.ts
@@ -1,7 +1,7 @@
 import axios, { Axios, AxiosResponse, RawAxiosRequestConfig, isAxiosError } from "axios";
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync } from "fs";
 import { Agent } from "https";
-import { logDebug } from "../logging/logging";
+import { logDebug, writeFile } from "../logging/logging";
 import { InternalOptions } from "../types/plugin";
 import { normalizedFilename } from "../util/files";
 
@@ -38,14 +38,14 @@ export class Requests {
                             `${method}_${url}_${timestamp}_request.json`
                         );
                         logDebug(`Writing request to ${filename}.`);
-                        writeFileSync(
-                            filename,
-                            JSON.stringify({
+                        writeFile(
+                            {
                                 url: url,
                                 headers: request.headers,
                                 params: request.params,
                                 body: request.data,
-                            })
+                            },
+                            filename
                         );
                         return request;
                     },
@@ -65,7 +65,7 @@ export class Requests {
                             data = error;
                         }
                         logDebug(`Writing request to ${filename}.`);
-                        writeFileSync(filename, JSON.stringify(data));
+                        writeFile(data, filename);
                         throw error;
                     }
                 );
@@ -78,14 +78,14 @@ export class Requests {
                             `${method}_${url}_${timestamp}_response.json`
                         );
                         logDebug(`Writing response to ${filename}.`);
-                        writeFileSync(
-                            filename,
-                            JSON.stringify({
+                        writeFile(
+                            {
                                 data: response.data,
                                 headers: response.headers,
                                 status: response.status,
                                 statusText: response.statusText,
-                            })
+                            },
+                            filename
                         );
                         return response;
                     },
@@ -105,7 +105,7 @@ export class Requests {
                             data = error;
                         }
                         logDebug(`Writing response to ${filename}.`);
-                        writeFileSync(filename, JSON.stringify(data));
+                        writeFile(data, filename);
                         throw error;
                     }
                 );

--- a/src/logging/logging.spec.ts
+++ b/src/logging/logging.spec.ts
@@ -1,0 +1,141 @@
+/// <reference types="cypress" />
+
+import { AxiosError, AxiosHeaders } from "axios";
+import { expect } from "chai";
+import fs from "fs";
+import path from "path";
+import { TEST_TMP_DIR, stubLogError } from "../../test/util";
+import { initLogging, writeErrorFile } from "./logging";
+
+describe("the logging module", () => {
+    describe("writeErrorFile", () => {
+        const LOG_ROOT = `${TEST_TMP_DIR}/logs`;
+
+        it("should be able to write to relative directories", () => {
+            initLogging({
+                logDirectory: `./${LOG_ROOT}`,
+            });
+            const stubbedError = stubLogError();
+            writeErrorFile(
+                new Error(
+                    JSON.stringify({
+                        something: "else",
+                    })
+                ),
+                "writeErrorFileRelative"
+            );
+            const expectedPath = path.resolve(LOG_ROOT, "writeErrorFileRelative.json");
+            expect(stubbedError).to.have.been.calledOnceWithExactly(
+                `Complete error logs have been written to "${expectedPath}"`
+            );
+            expect(JSON.parse(fs.readFileSync(expectedPath).toString())).to.deep.eq({
+                something: "else",
+            });
+        });
+
+        it("should be able to write to absolute directories", () => {
+            initLogging({
+                logDirectory: path.resolve(LOG_ROOT),
+            });
+            const stubbedError = stubLogError();
+            writeErrorFile(
+                new Error(
+                    JSON.stringify({
+                        something: "entirely else",
+                    })
+                ),
+                "writeErrorFileAbsolute"
+            );
+            const expectedPath = path.resolve(LOG_ROOT, "writeErrorFileAbsolute.json");
+            expect(stubbedError).to.have.been.calledOnceWithExactly(
+                `Complete error logs have been written to "${expectedPath}"`
+            );
+            expect(JSON.parse(fs.readFileSync(expectedPath).toString())).to.deep.eq({
+                something: "entirely else",
+            });
+        });
+
+        it("should be able to write to non-existent directories", () => {
+            const timestamp = Date.now();
+            initLogging({
+                logDirectory: `./${LOG_ROOT}/${timestamp}`,
+            });
+            const stubbedError = stubLogError();
+            writeErrorFile(
+                new Error(
+                    JSON.stringify({
+                        something: "entirely different",
+                    })
+                ),
+                "writeErrorFileNonExistent"
+            );
+            const expectedPath = path.resolve(
+                LOG_ROOT,
+                timestamp.toString(),
+                "writeErrorFileNonExistent.json"
+            );
+            expect(stubbedError).to.have.been.calledOnceWithExactly(
+                `Complete error logs have been written to "${expectedPath}"`
+            );
+            expect(JSON.parse(fs.readFileSync(expectedPath).toString())).to.deep.eq({
+                something: "entirely different",
+            });
+        });
+
+        it("should be able to write axios errors", () => {
+            const timestamp = Date.now();
+            initLogging({
+                logDirectory: `./${LOG_ROOT}/${timestamp}`,
+            });
+            const stubbedError = stubLogError();
+            writeErrorFile(
+                new AxiosError("Request failed with status code 400", "400", null, null, {
+                    status: 400,
+                    statusText: "Bad Request",
+                    config: { headers: new AxiosHeaders({ Authorization: "Bearer 123456790" }) },
+                    headers: {},
+                    data: {
+                        error: "Must provide a project key",
+                    },
+                }),
+                "writeErrorFileAxios"
+            );
+            const expectedPath = path.resolve(
+                LOG_ROOT,
+                timestamp.toString(),
+                "writeErrorFileAxios.json"
+            );
+            expect(stubbedError).to.have.been.calledOnceWithExactly(
+                `Complete error logs have been written to "${expectedPath}"`
+            );
+            const parsedData = JSON.parse(fs.readFileSync(expectedPath).toString());
+            expect(parsedData.error.message).to.eq("Request failed with status code 400");
+            expect(parsedData.error.name).to.eq("AxiosError");
+            expect(parsedData.error.code).to.eq("400");
+            expect(parsedData.error.status).to.eq(400);
+            expect(parsedData.response).to.deep.eq({
+                error: "Must provide a project key",
+            });
+        });
+
+        it("should be able to write generic errors", () => {
+            const timestamp = Date.now();
+            initLogging({
+                logDirectory: `./${LOG_ROOT}/${timestamp}`,
+            });
+            const stubbedError = stubLogError();
+            writeErrorFile({ good: "morning" }, "writeErrorFileGeneric");
+            const expectedPath = path.resolve(
+                LOG_ROOT,
+                timestamp.toString(),
+                "writeErrorFileGeneric.log"
+            );
+            expect(stubbedError).to.have.been.calledOnceWithExactly(
+                `Complete error logs have been written to "${expectedPath}"`
+            );
+            expect(JSON.parse(fs.readFileSync(expectedPath).toString())).to.deep.eq({
+                good: "morning",
+            });
+        });
+    });
+});

--- a/src/logging/logging.ts
+++ b/src/logging/logging.ts
@@ -46,6 +46,20 @@ export const logDebug = (...text: string[]) => {
 };
 
 /**
+ * Writes arbitrary data to a file under the log path configured in
+ * {@link initLogging `initLogging`}.
+ *
+ * @param data the data to write
+ * @param filename the filename to use for the file
+ */
+export function writeFile<T>(data: T, filename: string): void {
+    const logDirectoryPath = path.resolve(loggingOptions.logDirectory);
+    fs.mkdirSync(logDirectoryPath, { recursive: true });
+    const filepath = path.resolve(logDirectoryPath, filename);
+    fs.writeFileSync(filepath, JSON.stringify(data));
+}
+
+/**
  * Writes an error to a file (e.g. HTTP response errors) under the log path configured in
  * {@link initLogging `initLogging`}.
  *

--- a/src/logging/logging.ts
+++ b/src/logging/logging.ts
@@ -1,4 +1,7 @@
+import { isAxiosError } from "axios";
 import chalk from "chalk";
+import fs from "fs";
+import path from "path";
 
 const INFO = "INFO";
 const ERROR = "ERROR";
@@ -9,26 +12,65 @@ const DEBUG = "DEBUG";
 const VARIANTS = [INFO, ERROR, SUCCESS, WARNING, DEBUG];
 const MAX_PREFIX_LENGTH = Math.max(...VARIANTS.map((s) => s.length));
 
+export interface LoggingOptions {
+    logDirectory: string;
+}
+
+let loggingOptions: LoggingOptions;
+
+export function initLogging(options: LoggingOptions) {
+    loggingOptions = options;
+}
 function prefix(type: string): string {
     return chalk.white(`| Cypress Xray Plugin | ${type.padEnd(MAX_PREFIX_LENGTH, " ")} |`);
 }
 
-export function logInfo(...text: string[]) {
+export const logInfo = (...text: string[]) => {
     console.info(prefix(INFO), chalk.gray(text.join(" ")));
-}
+};
 
-export function logError(...text: string[]) {
+export const logError = (...text: string[]) => {
     console.error(prefix(ERROR), chalk.red(text.join(" ")));
-}
+};
 
-export function logSuccess(...text: string[]) {
+export const logSuccess = (...text: string[]) => {
     console.log(prefix(SUCCESS), chalk.green(text.join(" ")));
-}
+};
 
-export function logWarning(...text: string[]) {
+export const logWarning = (...text: string[]) => {
     console.warn(prefix(WARNING), chalk.yellow(text.join(" ")));
-}
+};
 
-export function logDebug(...text: string[]) {
+export const logDebug = (...text: string[]) => {
     console.warn(prefix(DEBUG), chalk.cyan(text.join(" ")));
+};
+
+/**
+ * Writes an error to a file (e.g. HTTP response errors) under the log path configured in
+ * {@link initLogging `initLogging`}.
+ *
+ * @param error the error
+ * @param filename the filename to use for the file
+ */
+export function writeErrorFile(error: unknown, filename: string): void {
+    let errorFileName: string;
+    let errorData: string;
+    if (isAxiosError(error)) {
+        errorFileName = `${filename}.json`;
+        errorData = JSON.stringify({
+            error: error.toJSON(),
+            response: error.response?.data,
+        });
+    } else if (error instanceof Error) {
+        errorFileName = `${filename}.json`;
+        errorData = error.message;
+    } else {
+        errorFileName = `${filename}.log`;
+        errorData = JSON.stringify(error);
+    }
+    const logDirectoryPath = path.resolve(loggingOptions.logDirectory);
+    fs.mkdirSync(logDirectoryPath, { recursive: true });
+    errorFileName = path.resolve(logDirectoryPath, errorFileName);
+    fs.writeFileSync(errorFileName, errorData);
+    logError(`Complete error logs have been written to "${errorFileName}"`);
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -187,6 +187,10 @@ export interface PluginOptions {
      */
     debug?: boolean;
     /**
+     * The directory which all error and debug log files will be written to.
+     */
+    logDirectory?: string;
+    /**
      * Some Xray setups might struggle with uploaded evidence if the filenames contain non-ASCII
      * characters. With this option enabled, the plugin only allows characters `a-zA-Z0-9.` in
      * screenshot names and replaces all other sequences with `_`.

--- a/test/util.ts
+++ b/test/util.ts
@@ -19,7 +19,7 @@ afterEach(() => {
     Sinon.restore();
 });
 
-const TEST_TMP_DIR = "test/out";
+export const TEST_TMP_DIR = "test/out";
 
 export function getTestDir(dirName: string): string {
     return path.join(TEST_TMP_DIR, dirName);


### PR DESCRIPTION
This PR adds the `plugin.logDirectory` option, which allows users to specify a single directory where all log files (debug, HTTP request errors) will be written to:

  ```json
  "plugin": {
    "logDirectory": "/home/logs/"
  }
  ```

or on the fly using environment variables:

  ```sh
  PLUGIN_LOG_DIRECTORY="/home/logs/"
  ```

It defaults to `logs` relative to the current execution context (i.e. `./logs`).

- [x] Update documentation: https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/plugin/#logdirectory