### PR TITLE
Restrict exports to members exported in `index.ts`

### DIFF
--- a/index.spec.ts
+++ b/index.spec.ts
@@ -1,0 +1,71 @@
+import { expect } from "chai";
+import {
+    CypressXrayPluginOptions,
+    addXrayResultUpload,
+    configureXrayPlugin,
+    syncFeatureFile,
+} from "./index";
+
+// Make sure there are no accidental breaking changes for the plugin's exported members.
+// If there were, the compiler would complain about these tests.
+// These tests therefore somewhat simulate a real use case.
+describe("the plugin exports should work", () => {
+    it("addXrayResultUpload", () => {
+        expect(addXrayResultUpload).to.be.a("function");
+    });
+
+    it("configureXrayPlugin", () => {
+        expect(configureXrayPlugin).to.be.a("function");
+    });
+
+    it("addXrayResultUpload", () => {
+        expect(syncFeatureFile).to.be.a("function");
+    });
+
+    describe("CypressXrayPluginOptions", () => {
+        it("default", () => {
+            const options: CypressXrayPluginOptions = {
+                jira: undefined,
+            };
+            expect(options).to.exist;
+        });
+        it("jira", () => {
+            const options: CypressXrayPluginOptions = {
+                jira: {
+                    projectKey: "CYP-123",
+                },
+            };
+            expect(options).to.exist;
+        });
+        it("xray", () => {
+            const options: CypressXrayPluginOptions = {
+                jira: undefined,
+                xray: {},
+            };
+            expect(options).to.exist;
+        });
+        it("cucumber", () => {
+            const options: CypressXrayPluginOptions = {
+                jira: undefined,
+                cucumber: {
+                    featureFileExtension: ".feature",
+                },
+            };
+            expect(options).to.exist;
+        });
+        it("plugin", () => {
+            const options: CypressXrayPluginOptions = {
+                jira: undefined,
+                plugin: {},
+            };
+            expect(options).to.exist;
+        });
+        it("openSSL", () => {
+            const options: CypressXrayPluginOptions = {
+                jira: undefined,
+                openSSL: {},
+            };
+            expect(options).to.exist;
+        });
+    });
+});

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,9 @@
+import { addXrayResultUpload, configureXrayPlugin, syncFeatureFile } from "./src/plugin";
+import { Options } from "./src/types/plugin";
+
+export {
+    Options as CypressXrayPluginOptions,
+    addXrayResultUpload,
+    configureXrayPlugin,
+    syncFeatureFile,
+};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "*.js",
         "*.ts"
     ],
+    "exports": "./index.js",
     "directories": {
         "lib": "src"
     },

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -2,9 +2,9 @@
 
 import { expect } from "chai";
 import fs from "fs";
+import { stubLogInfo } from "../test/util";
 import { configureXrayPlugin } from "./plugin";
-import { Options } from "./src/types/plugin";
-import { stubLogInfo } from "./test/util";
+import { Options } from "./types/plugin";
 
 describe("the plugin configuration", () => {
     const config: Cypress.PluginConfigOptions = JSON.parse(

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,10 +1,10 @@
 /// <reference types="cypress" />
 
-import { initJiraClient, initOptions, initXrayClient, verifyContext } from "./src/context";
-import { afterRunHook, synchronizeFile } from "./src/hooks";
-import { Requests } from "./src/https/requests";
-import { logInfo } from "./src/logging/logging";
-import { Options, PluginContext } from "./src/types/plugin";
+import { initJiraClient, initOptions, initXrayClient, verifyContext } from "./context";
+import { afterRunHook, synchronizeFile } from "./hooks";
+import { Requests } from "./https/requests";
+import { logInfo } from "./logging/logging";
+import { Options, PluginContext } from "./types/plugin";
 
 let context: PluginContext;
 


### PR DESCRIPTION
Currently, the plugin exports all its internally used modules, types and classes. This PR restricts the available imports to the ones defined in `index.ts`.

This is a breaking change and requires updates to all `cypress-xray-plugin` imports:

```ts
// old
import { addXrayResultUpload, configureXrayPlugin, syncFeatureFile } from "cypress-xray-plugin/plugin";
// new
import { addXrayResultUpload, configureXrayPlugin, syncFeatureFile } from "cypress-xray-plugin";
```

- [x] Update documentation: https://github.com/Qytera-Gmbh/Qytera-Gmbh.github.io/pull/8