### PR TITLE
Stop updating manual test steps by default

### DIFF
--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -78,7 +78,7 @@ describe("the plugin context configuration", () => {
                         expect(options.xray.steps.maxLengthAction).to.eq(8000);
                     });
                     it("update", () => {
-                        expect(options.xray.steps.update).to.eq(true);
+                        expect(options.xray.steps.update).to.eq(false);
                     });
                 });
                 it("uploadResults", () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -99,7 +99,7 @@ export function initOptions(env: Cypress.ObjectLike, options: Options): Internal
                 update:
                     parse(env, ENV_XRAY_STEPS_UPDATE, asBoolean) ??
                     options.xray?.steps?.update ??
-                    true,
+                    false,
             },
             uploadResults:
                 parse(env, ENV_XRAY_UPLOAD_RESULTS, asBoolean) ??

--- a/src/conversion/importExecution/importExecutionConverter.spec.ts
+++ b/src/conversion/importExecution/importExecutionConverter.spec.ts
@@ -267,6 +267,7 @@ describe("the import execution converters", () => {
                     "CYP-41": "Manual",
                     "CYP-49": "Cucumber",
                 };
+                options.xray.steps.update = true;
                 const json = await converter.convert(result, testIssueData);
                 expect(json.tests).to.have.length(3);
                 expect(json.tests[0].testInfo.steps).to.have.length(1);
@@ -291,7 +292,6 @@ describe("the import execution converters", () => {
                     "CYP-41": "Manual",
                     "CYP-49": "Cucumber",
                 };
-                options.xray.steps.update = false;
                 const json = await converter.convert(result, testIssueData);
                 expect(json.tests).to.have.length(3);
                 expect(json.tests[0].testInfo.steps).to.be.undefined;
@@ -313,6 +313,7 @@ describe("the import execution converters", () => {
                     "CYP-456": "Manual",
                     "CYP-789": "Manual",
                 };
+                options.xray.steps.update = true;
                 const json = await converter.convert(result, testIssueData);
                 expect(json.tests[0].testInfo.steps[0].action).to.eq(`${"x".repeat(7997)}...`);
                 expect(json.tests[1].testInfo.steps[0].action).to.eq(`${"x".repeat(8000)}`);
@@ -323,7 +324,6 @@ describe("the import execution converters", () => {
                 const result: CypressCommandLine.CypressRunResult = JSON.parse(
                     readFileSync("./test/resources/runResultLongBodies.json", "utf-8")
                 );
-                options.xray.steps.maxLengthAction = 5;
                 testIssueData.summaries = {
                     "CYP-123": "1st summary",
                     "CYP-456": "2nd summary",
@@ -334,6 +334,8 @@ describe("the import execution converters", () => {
                     "CYP-456": "Manual",
                     "CYP-789": "Manual",
                 };
+                options.xray.steps.update = true;
+                options.xray.steps.maxLengthAction = 5;
                 const json = await converter.convert(result, testIssueData);
                 expect(json.tests[0].testInfo.steps[0].action).to.eq("xx...");
                 expect(json.tests[1].testInfo.steps[0].action).to.eq("xx...");

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -96,7 +96,7 @@ export interface XrayStepOptions {
     maxLengthAction?: number;
     /**
      * Whether to update a manual test issue's test steps during execution results upload. If set
-     * to true, **all** existing steps will be replaced with the plugin's steps.
+     * to true, all existing steps ***will be replaced*** with the plugin's steps.
      *
      * Note: the plugin currently creates only one step containing the code of the corresponding
      * Cypress test function.


### PR DESCRIPTION
This PR changes the default behaviour of `xray.steps.update` from `true` to `false`. Step updates will require explicit approval instead of blindly replacing existing steps by default from now on.