### PR TITLE
Move client logging to debug output

### DIFF
--- a/src/client/jira/jiraClient.spec.ts
+++ b/src/client/jira/jiraClient.spec.ts
@@ -4,7 +4,6 @@ import fs from "fs";
 import { expectToExist, resolveTestDirPath, stubLogging, stubRequests } from "../../../test/util";
 import { BasicAuthCredentials } from "../../authentication/credentials";
 import { SearchResultsServer } from "../../types/jira/responses/searchResults";
-import { dedent } from "../../util/dedent";
 import { JiraClientCloud } from "./jiraClientCloud";
 import { JiraClientServer } from "./jiraClientServer";
 
@@ -53,33 +52,6 @@ describe("the jira clients", () => {
                 });
 
                 describe("single file attachment", () => {
-                    it("logs correct messages", async () => {
-                        const { stubbedInfo, stubbedSuccess } = stubLogging();
-                        const { stubbedPost } = stubRequests();
-                        stubbedPost.resolves({
-                            status: HttpStatusCode.Ok,
-                            data: JSON.parse(
-                                fs.readFileSync(
-                                    "./test/resources/fixtures/jira/responses/singleAttachment.json",
-                                    "utf-8"
-                                )
-                            ),
-                            headers: null,
-                            statusText: HttpStatusCode[HttpStatusCode.Ok],
-                            config: null,
-                        });
-                        await client.addAttachment("CYP-123", "./test/resources/turtle.png");
-                        expect(stubbedInfo).to.have.been.calledWithExactly(
-                            "Attaching files:",
-                            "./test/resources/turtle.png"
-                        );
-                        expect(stubbedSuccess).to.have.been.calledOnceWith(
-                            dedent(`
-                                Successfully attached files to issue: CYP-123
-                                  turtle.png
-                            `)
-                        );
-                    });
                     it("returns the correct values", async () => {
                         stubLogging();
                         const { stubbedPost } = stubRequests();
@@ -105,39 +77,6 @@ describe("the jira clients", () => {
                 });
 
                 describe("multiple file attachment", () => {
-                    it("logs correct messages", async () => {
-                        const { stubbedInfo, stubbedSuccess } = stubLogging();
-                        const { stubbedPost } = stubRequests();
-                        stubbedPost.resolves({
-                            status: HttpStatusCode.Ok,
-                            data: JSON.parse(
-                                fs.readFileSync(
-                                    "./test/resources/fixtures/jira/responses/multipleAttachments.json",
-                                    "utf-8"
-                                )
-                            ),
-                            headers: null,
-                            statusText: HttpStatusCode[HttpStatusCode.Ok],
-                            config: null,
-                        });
-                        await client.addAttachment(
-                            "CYP-123",
-                            "./test/resources/turtle.png",
-                            "./test/resources/greetings.txt"
-                        );
-                        expect(stubbedInfo).to.have.been.calledWithExactly(
-                            "Attaching files:",
-                            "./test/resources/turtle.png",
-                            "./test/resources/greetings.txt"
-                        );
-                        expect(stubbedSuccess).to.have.been.calledOnceWith(
-                            dedent(`
-                                Successfully attached files to issue: CYP-123
-                                  turtle.png
-                                  greetings.txt
-                            `)
-                        );
-                    });
                     it("returns the correct values", async () => {
                         stubLogging();
                         const { stubbedPost } = stubRequests();
@@ -276,27 +215,6 @@ describe("the jira clients", () => {
             });
 
             describe("get fields", () => {
-                it("logs correct messages", async () => {
-                    const { stubbedInfo, stubbedSuccess } = stubLogging();
-                    const { stubbedGet } = stubRequests();
-                    stubbedGet.onFirstCall().resolves({
-                        status: HttpStatusCode.Ok,
-                        data: JSON.parse(
-                            fs.readFileSync(
-                                "./test/resources/fixtures/jira/responses/getFields.json",
-                                "utf-8"
-                            )
-                        ),
-                        headers: null,
-                        statusText: HttpStatusCode[HttpStatusCode.Ok],
-                        config: null,
-                    });
-                    await client.getFields();
-                    expect(stubbedInfo).to.have.been.calledWithExactly("Getting fields...");
-                    expect(stubbedSuccess).to.have.been.calledOnceWith(
-                        "Successfully retrieved data for 141 fields"
-                    );
-                });
                 it("returns the correct values", async () => {
                     stubLogging();
                     const { stubbedGet } = stubRequests();
@@ -351,28 +269,6 @@ describe("the jira clients", () => {
             });
 
             describe("search", () => {
-                it("logs correct messages", async () => {
-                    const { stubbedInfo, stubbedSuccess } = stubLogging();
-                    const { stubbedPost } = stubRequests();
-                    stubbedPost.onFirstCall().resolves({
-                        status: HttpStatusCode.Ok,
-                        data: JSON.parse(
-                            fs.readFileSync(
-                                "./test/resources/fixtures/jira/responses/search.json",
-                                "utf-8"
-                            )
-                        ),
-                        headers: null,
-                        statusText: HttpStatusCode[HttpStatusCode.Ok],
-                        config: null,
-                    });
-                    await client.search({
-                        jql: "project = CYP AND issue in (CYP-268,CYP-237,CYP-332,CYP-333,CYP-338)",
-                        fields: ["customfield_12100"],
-                    });
-                    expect(stubbedInfo).to.have.been.calledOnceWithExactly("Searching issues...");
-                    expect(stubbedSuccess).to.have.been.calledOnceWithExactly("Found 5 issues");
-                });
                 it("should return all issues without pagination", async () => {
                     stubLogging();
                     const { stubbedPost } = stubRequests();
@@ -495,25 +391,6 @@ describe("the jira clients", () => {
             });
 
             describe("editIssue", () => {
-                it("logs correct messages", async () => {
-                    const { stubbedInfo, stubbedSuccess } = stubLogging();
-                    const { stubbedPut } = stubRequests();
-                    stubbedPut.onFirstCall().resolves({
-                        status: HttpStatusCode.NoContent,
-                        data: null,
-                        headers: null,
-                        statusText: HttpStatusCode[HttpStatusCode.NoContent],
-                        config: null,
-                    });
-                    await client.editIssue("CYP-123", {
-                        fields: { summary: "Hello" },
-                    });
-                    expect(stubbedInfo).to.have.been.calledOnceWithExactly("Editing issue...");
-                    expect(stubbedSuccess).to.have.been.calledOnceWithExactly(
-                        "Successfully edited issue: CYP-123"
-                    );
-                });
-
                 it("should handle bad responses", async () => {
                     const { stubbedError } = stubLogging();
                     const { stubbedPut } = stubRequests();

--- a/src/client/jira/jiraClient.ts
+++ b/src/client/jira/jiraClient.ts
@@ -3,14 +3,7 @@ import FormData from "form-data";
 import fs from "fs";
 import { BasicAuthCredentials, HTTPHeader, PATCredentials } from "../../authentication/credentials";
 import { Requests } from "../../https/requests";
-import {
-    logDebug,
-    logError,
-    logInfo,
-    logSuccess,
-    logWarning,
-    writeErrorFile,
-} from "../../logging/logging";
+import { logDebug, logError, logWarning, writeErrorFile } from "../../logging/logging";
 import { SearchRequestCloud, SearchRequestServer } from "../../types/jira/requests/search";
 import { AttachmentCloud, AttachmentServer } from "../../types/jira/responses/attachment";
 import { FieldDetailCloud, FieldDetailServer } from "../../types/jira/responses/fieldDetail";
@@ -86,7 +79,7 @@ export abstract class JiraClient<
             return await this.credentials
                 .getAuthenticationHeader()
                 .then(async (header: HTTPHeader) => {
-                    logInfo("Attaching files:", ...files);
+                    logDebug("Attaching files:", ...files);
                     const progressInterval = this.startResponseInterval(this.apiBaseURL);
                     try {
                         const response: AxiosResponse<AttachmentType[]> = await Requests.post(
@@ -100,7 +93,7 @@ export abstract class JiraClient<
                                 },
                             }
                         );
-                        logSuccess(
+                        logDebug(
                             dedent(`
                                 Successfully attached files to issue: ${issueIdOrKey}
                                   ${response.data
@@ -137,7 +130,7 @@ export abstract class JiraClient<
     public async getIssueTypes(): Promise<IssueTypeDetailsResponse[] | undefined> {
         try {
             const authenticationHeader = await this.credentials.getAuthenticationHeader();
-            logInfo("Getting issue types...");
+            logDebug("Getting issue types...");
             const progressInterval = this.startResponseInterval(this.apiBaseURL);
             try {
                 const response: AxiosResponse<IssueTypeDetailsResponse[]> = await Requests.get(
@@ -148,7 +141,7 @@ export abstract class JiraClient<
                         },
                     }
                 );
-                logSuccess(`Successfully retrieved data for ${response.data.length} issue types.`);
+                logDebug(`Successfully retrieved data for ${response.data.length} issue types.`);
                 logDebug(
                     dedent(`
                         Received data for issue types:
@@ -194,7 +187,7 @@ export abstract class JiraClient<
     public async getFields(): Promise<FieldDetailType[] | undefined> {
         try {
             const authenticationHeader = await this.credentials.getAuthenticationHeader();
-            logInfo("Getting fields...");
+            logDebug("Getting fields...");
             const progressInterval = this.startResponseInterval(this.apiBaseURL);
             try {
                 const response: AxiosResponse<FieldDetailType[]> = await Requests.get(
@@ -205,7 +198,7 @@ export abstract class JiraClient<
                         },
                     }
                 );
-                logSuccess(`Successfully retrieved data for ${response.data.length} fields`);
+                logDebug(`Successfully retrieved data for ${response.data.length} fields`);
                 logDebug(
                     dedent(`
                         Received data for fields:
@@ -244,7 +237,7 @@ export abstract class JiraClient<
             return await this.credentials
                 .getAuthenticationHeader()
                 .then(async (header: HTTPHeader) => {
-                    logInfo("Searching issues...");
+                    logDebug("Searching issues...");
                     const progressInterval = this.startResponseInterval(this.apiBaseURL);
                     try {
                         let total = 0;
@@ -267,7 +260,7 @@ export abstract class JiraClient<
                             total = response.data.total;
                             startAt = response.data.startAt + response.data.issues.length;
                         } while (startAt && startAt < total);
-                        logSuccess(`Found ${total} issues`);
+                        logDebug(`Found ${total} issues`);
                         return results;
                     } finally {
                         clearInterval(progressInterval);
@@ -305,7 +298,7 @@ export abstract class JiraClient<
     ): Promise<string | undefined> {
         try {
             await this.credentials.getAuthenticationHeader().then(async (header: HTTPHeader) => {
-                logInfo("Editing issue...");
+                logDebug("Editing issue...");
                 const progressInterval = this.startResponseInterval(this.apiBaseURL);
                 try {
                     await Requests.put(this.getUrlEditIssue(issueIdOrKey), issueUpdateData, {
@@ -313,7 +306,7 @@ export abstract class JiraClient<
                             ...header,
                         },
                     });
-                    logSuccess(`Successfully edited issue: ${issueIdOrKey}`);
+                    logDebug(`Successfully edited issue: ${issueIdOrKey}`);
                 } finally {
                     clearInterval(progressInterval);
                 }

--- a/src/client/xray/xrayClient.ts
+++ b/src/client/xray/xrayClient.ts
@@ -7,7 +7,7 @@ import {
     PATCredentials,
 } from "../../authentication/credentials";
 import { RequestConfigPost, Requests } from "../../https/requests";
-import { logError, logInfo, logSuccess, logWarning, writeErrorFile } from "../../logging/logging";
+import { logDebug, logError, logWarning, writeErrorFile } from "../../logging/logging";
 import { OneOf } from "../../types/util";
 import {
     XrayTestExecutionResultsCloud,
@@ -54,7 +54,7 @@ export abstract class XrayClient<
             const authenticationHeader = await this.credentials.getAuthenticationHeader(
                 `${this.apiBaseURL}/authenticate`
             );
-            logInfo("Importing execution...");
+            logDebug("Importing execution...");
             const progressInterval = this.startResponseInterval(this.apiBaseURL);
             try {
                 const response: AxiosResponse<ImportExecutionResponseType> = await Requests.post(
@@ -67,7 +67,7 @@ export abstract class XrayClient<
                     }
                 );
                 const key = this.handleResponseImportExecution(response.data);
-                logSuccess(`Successfully uploaded test execution results to ${key}.`);
+                logDebug(`Successfully uploaded test execution results to ${key}.`);
                 return key;
             } finally {
                 clearInterval(progressInterval);
@@ -109,7 +109,7 @@ export abstract class XrayClient<
             const authenticationHeader = await this.credentials.getAuthenticationHeader(
                 `${this.apiBaseURL}/authenticate`
             );
-            logInfo("Exporting Cucumber tests...");
+            logDebug("Exporting Cucumber tests...");
             const progressInterval = this.startResponseInterval(this.apiBaseURL);
             try {
                 const response = await Requests.get(this.getUrlExportCucumber(keys, filter), {
@@ -165,7 +165,7 @@ export abstract class XrayClient<
             const authenticationHeader = await this.credentials.getAuthenticationHeader(
                 `${this.apiBaseURL}/authenticate`
             );
-            logInfo("Importing Cucumber features...");
+            logDebug("Importing Cucumber features...");
             const progressInterval = this.startResponseInterval(this.apiBaseURL);
             try {
                 const fileContent = fs.createReadStream(file);
@@ -234,7 +234,7 @@ export abstract class XrayClient<
                 logWarning("No Cucumber tests were executed. Skipping Cucumber upload.");
                 return null;
             }
-            logInfo("Importing execution (Cucumber)...");
+            logDebug("Importing execution (Cucumber)...");
             const request = await this.prepareRequestImportExecutionCucumberMultipart(
                 cucumberJson,
                 cucumberInfo
@@ -247,7 +247,7 @@ export abstract class XrayClient<
                     request.config
                 );
                 const key = this.handleResponseImportExecutionCucumberMultipart(response.data);
-                logSuccess(`Successfully uploaded Cucumber test execution results to ${key}.`);
+                logDebug(`Successfully uploaded Cucumber test execution results to ${key}.`);
                 return key;
             } finally {
                 clearInterval(progressInterval);

--- a/src/client/xray/xrayClientCloud.spec.ts
+++ b/src/client/xray/xrayClientCloud.spec.ts
@@ -17,7 +17,6 @@ describe("the xray cloud client", () => {
     describe("import execution", () => {
         it("should handle successful responses", async () => {
             const { stubbedPost } = stubRequests();
-            const { stubbedInfo, stubbedSuccess } = stubLogging();
             stubbedPost.onFirstCall().resolves({
                 status: HttpStatusCode.Ok,
                 data: {
@@ -57,14 +56,10 @@ describe("the xray cloud client", () => {
                 ],
             });
             expect(response).to.eq("CYP-123");
-            expect(stubbedInfo).to.have.been.calledWithExactly("Importing execution...");
-            expect(stubbedSuccess).to.have.been.calledWithExactly(
-                "Successfully uploaded test execution results to CYP-123."
-            );
         });
         it("should handle bad responses", async () => {
             const { stubbedPost } = stubRequests();
-            const { stubbedInfo, stubbedError } = stubLogging();
+            const { stubbedError } = stubLogging();
             stubbedPost.onFirstCall().rejects(
                 new AxiosError("Request failed with status code 400", "400", null, null, {
                     status: 400,
@@ -93,7 +88,6 @@ describe("the xray cloud client", () => {
                 ],
             });
             expect(response).to.be.undefined;
-            expect(stubbedInfo).to.have.been.calledWithExactly("Importing execution...");
             expect(stubbedError).to.have.been.calledTwice;
             expect(stubbedError).to.have.been.calledWithExactly(
                 "Failed to import execution: AxiosError: Request failed with status code 400"
@@ -108,7 +102,6 @@ describe("the xray cloud client", () => {
     describe("import execution cucumber multipart", () => {
         it("should handle successful responses", async () => {
             const { stubbedPost } = stubRequests();
-            const { stubbedInfo, stubbedSuccess } = stubLogging();
             stubbedPost.onFirstCall().resolves({
                 status: HttpStatusCode.Ok,
                 data: {
@@ -135,15 +128,11 @@ describe("the xray cloud client", () => {
                 )
             );
             expect(response).to.eq("CYP-123");
-            expect(stubbedInfo).to.have.been.calledWithExactly("Importing execution (Cucumber)...");
-            expect(stubbedSuccess).to.have.been.calledWithExactly(
-                "Successfully uploaded Cucumber test execution results to CYP-123."
-            );
         });
 
         it("should handle bad responses", async () => {
             const { stubbedPost } = stubRequests();
-            const { stubbedInfo, stubbedError } = stubLogging();
+            const { stubbedError } = stubLogging();
             stubbedPost.onFirstCall().rejects(
                 new AxiosError("Request failed with status code 400", "400", null, null, {
                     status: 400,
@@ -170,7 +159,6 @@ describe("the xray cloud client", () => {
                 )
             );
             expect(response).to.be.undefined;
-            expect(stubbedInfo).to.have.been.calledWithExactly("Importing execution (Cucumber)...");
             expect(stubbedError).to.have.been.calledWithExactly(
                 "Failed to import Cucumber execution: AxiosError: Request failed with status code 400"
             );
@@ -184,7 +172,6 @@ describe("the xray cloud client", () => {
     describe("get test types", () => {
         it("should handle successful responses", async () => {
             const { stubbedPost } = stubRequests();
-            const { stubbedInfo, stubbedSuccess } = stubLogging();
             stubbedPost.onFirstCall().resolves({
                 status: HttpStatusCode.Ok,
                 data: JSON.parse(
@@ -203,15 +190,10 @@ describe("the xray cloud client", () => {
                 "CYP-331": "Cucumber",
                 "CYP-332": "Manual",
             });
-            expect(stubbedInfo).to.have.been.calledWithExactly("Retrieving test types...");
-            expect(stubbedSuccess).to.have.been.calledWithExactly(
-                "Successfully retrieved test types for 3 issues"
-            );
         });
 
         it("should paginate big requests", async () => {
             const { stubbedPost } = stubRequests();
-            const { stubbedInfo, stubbedSuccess } = stubLogging();
             const mockedData: GetTestsResponse<unknown> = JSON.parse(
                 fs.readFileSync(
                     "./test/resources/fixtures/xray/responses/getTestsTypes.json",
@@ -268,10 +250,6 @@ describe("the xray cloud client", () => {
                 "CYP-331": "Cucumber",
                 "CYP-332": "Manual",
             });
-            expect(stubbedInfo).to.have.been.calledWithExactly("Retrieving test types...");
-            expect(stubbedSuccess).to.have.been.calledWithExactly(
-                "Successfully retrieved test types for 3 issues"
-            );
         });
 
         it("should throw for missing test types", async () => {

--- a/src/client/xray/xrayClientCloud.ts
+++ b/src/client/xray/xrayClientCloud.ts
@@ -1,7 +1,7 @@
 import FormData from "form-data";
 import { JWTCredentials } from "../../authentication/credentials";
 import { RequestConfigPost, Requests } from "../../https/requests";
-import { logError, logInfo, logSuccess, logWarning, writeErrorFile } from "../../logging/logging";
+import { logDebug, logError, logWarning, writeErrorFile } from "../../logging/logging";
 import { StringMap } from "../../types/util";
 import { CucumberMultipartFeature } from "../../types/xray/requests/importExecutionCucumberMultipart";
 import {
@@ -84,13 +84,13 @@ export class XrayClientCloud extends XrayClient<
             logError("Encountered some errors during import:", ...response.errors);
         }
         if (response.updatedOrCreatedTests.length > 0) {
-            logSuccess(
+            logDebug(
                 "Successfully updated or created test issues:",
                 response.updatedOrCreatedTests.map((issue: IssueDetails) => issue.key).join(", ")
             );
         }
         if (response.updatedOrCreatedPreconditions.length > 0) {
-            logSuccess(
+            logDebug(
                 "Successfully updated or created precondition issues:",
                 response.updatedOrCreatedPreconditions
                     .map((issue: IssueDetails) => issue.key)
@@ -120,7 +120,7 @@ export class XrayClientCloud extends XrayClient<
             const authenticationHeader = await this.credentials.getAuthenticationHeader(
                 `${this.apiBaseURL}/authenticate`
             );
-            logInfo("Retrieving test types...");
+            logDebug("Retrieving test types...");
             const progressInterval = this.startResponseInterval(this.apiBaseURL);
             try {
                 const types = {};
@@ -181,7 +181,7 @@ export class XrayClientCloud extends XrayClient<
                         `)
                     );
                 }
-                logSuccess(`Successfully retrieved test types for ${issueKeys.length} issues`);
+                logDebug(`Successfully retrieved test types for ${issueKeys.length} issues`);
                 return types;
             } finally {
                 clearInterval(progressInterval);

--- a/src/client/xray/xrayClientServer.spec.ts
+++ b/src/client/xray/xrayClientServer.spec.ts
@@ -1,7 +1,7 @@
 import { HttpStatusCode } from "axios";
 import { expect } from "chai";
 import fs from "fs";
-import { stubLogging, stubRequests } from "../../../test/util";
+import { stubRequests } from "../../../test/util";
 import { BasicAuthCredentials } from "../../authentication/credentials";
 import { JiraClientServer } from "../jira/jiraClientServer";
 import { XrayClientServer } from "./xrayClientServer";
@@ -16,7 +16,6 @@ describe("the xray server client", () => {
     describe("import execution", () => {
         it("should handle successful responses", async () => {
             const { stubbedPost } = stubRequests();
-            const { stubbedInfo, stubbedSuccess } = stubLogging();
             stubbedPost.resolves({
                 status: HttpStatusCode.Ok,
                 data: {
@@ -58,17 +57,12 @@ describe("the xray server client", () => {
                 ],
             });
             expect(response).to.eq("CYP-123");
-            expect(stubbedInfo).to.have.been.calledWithExactly("Importing execution...");
-            expect(stubbedSuccess).to.have.been.calledWithExactly(
-                "Successfully uploaded test execution results to CYP-123."
-            );
         });
     });
 
     describe("import execution cucumber multipart", () => {
         it("should handle successful responses", async () => {
             const { stubbedPost } = stubRequests();
-            const { stubbedInfo, stubbedSuccess } = stubLogging();
             stubbedPost.resolves({
                 status: HttpStatusCode.Ok,
                 data: {
@@ -97,10 +91,6 @@ describe("the xray server client", () => {
                 )
             );
             expect(response).to.eq("CYP-123");
-            expect(stubbedInfo).to.have.been.calledWithExactly("Importing execution (Cucumber)...");
-            expect(stubbedSuccess).to.have.been.calledWithExactly(
-                "Successfully uploaded Cucumber test execution results to CYP-123."
-            );
         });
     });
 

--- a/src/client/xray/xrayClientServer.ts
+++ b/src/client/xray/xrayClientServer.ts
@@ -1,7 +1,7 @@
 import FormData from "form-data";
 import { BasicAuthCredentials, PATCredentials } from "../../authentication/credentials";
 import { RequestConfigPost } from "../../https/requests";
-import { logError, logSuccess } from "../../logging/logging";
+import { logDebug, logError } from "../../logging/logging";
 import { CucumberMultipartFeature } from "../../types/xray/requests/importExecutionCucumberMultipart";
 import { CucumberMultipartInfoServer } from "../../types/xray/requests/importExecutionCucumberMultipartInfo";
 import { ImportExecutionResponseServer } from "../../types/xray/responses/importExecution";
@@ -74,19 +74,19 @@ export class XrayClientServer extends XrayClient<
                 logError("Encountered an error during import:", response.message);
             }
             if (response.testIssues.length > 0) {
-                logSuccess(
+                logDebug(
                     "Successfully updated or created test issues:",
                     response.testIssues.map((issue: IssueDetails) => issue.key).join(", ")
                 );
             }
             if (response.preconditionIssues.length > 0) {
-                logSuccess(
+                logDebug(
                     "Successfully updated or created precondition issues:",
                     response.preconditionIssues.map((issue: IssueDetails) => issue.key).join(", ")
                 );
             }
         } else if (Array.isArray(response)) {
-            logSuccess(
+            logDebug(
                 "Successfully updated or created issues:",
                 response.map((issue: IssueDetails) => issue.key).join(", ")
             );

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -9,7 +9,7 @@ import { ImportExecutionConverterCloud } from "./conversion/importExecution/impo
 import { ImportExecutionConverterServer } from "./conversion/importExecution/importExecutionConverterServer";
 import { ImportExecutionCucumberMultipartConverterCloud } from "./conversion/importExecutionCucumberMultipart/importExecutionCucumberMultipartConverterCloud";
 import { ImportExecutionCucumberMultipartConverterServer } from "./conversion/importExecutionCucumberMultipart/importExecutionCucumberMultipartConverterServer";
-import { logDebug, logError, logInfo, logWarning } from "./logging/logging";
+import { logDebug, logError, logInfo, logSuccess, logWarning } from "./logging/logging";
 import {
     FeatureFileIssueData,
     containsCucumberTest,
@@ -224,6 +224,7 @@ export async function afterRunHook(
     }
     let issueKey: string = null;
     if (containsNativeTest(runResult, options)) {
+        logInfo("Uploading native Cypress test results...");
         issueKey = await uploadCypressResults(
             runResult,
             options,
@@ -248,6 +249,7 @@ export async function afterRunHook(
         }
     }
     if (containsCucumberTest(runResult, options)) {
+        logInfo("Uploading Cucumber test results...");
         const cucumberIssueKey = await uploadCucumberResults(runResult, options, clients);
         if (
             options.jira.testExecutionIssueKey &&
@@ -286,6 +288,9 @@ export async function afterRunHook(
         logWarning("Execution results import was skipped. Skipping remaining tasks");
         return;
     }
+    logSuccess(
+        `Uploaded test results to issue: ${issueKey} (${options.jira.url}/browse/${issueKey})`
+    );
     if (options.jira.attachVideos) {
         await attachVideos(runResult, issueKey, clients.jiraClient);
     }
@@ -406,6 +411,7 @@ export async function synchronizeFile(
                           ${issueKeys.join("\n")}
                     `)
                 );
+                logInfo("Importing feature file to Xray...");
                 const testSummaries = await clients.jiraRepository.getSummaries(...issueKeys);
                 const wasImportSuccessful = await clients.xrayClient.importFeature(
                     file.filePath,


### PR DESCRIPTION
The clients are currently very verbose and print lots of noise (`Getting fields...`, `Getting test types...`, ...).

This PR moves all such logging statements to the debug level.