### PR TITLE
Reset issue labels after feature file import

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -513,7 +513,7 @@ async function resetLabels(
             if (!(await jiraClient.editIssue(issueKey, issueUpdate))) {
                 logError(
                     dedent(`
-                        Failed to reset issue summary of issue to its old summary: ${issueKey}
+                        Failed to reset issue labels of issue to its old labels: ${issueKey}
 
                           Labels pre sync:  ${oldLabels}
                           Labels post sync: ${newLabels}

--- a/src/preprocessing/preprocessing.ts
+++ b/src/preprocessing/preprocessing.ts
@@ -127,14 +127,19 @@ export function containsCucumberTest(
 }
 
 export interface FeatureFileIssueData {
-    tests: {
-        key: string;
-        summary: string;
-    }[];
-    preconditions: {
-        key: string;
-        summary: string;
-    }[];
+    tests: FeatureFileIssueDataTest[];
+    preconditions: FeatureFileIssueDataPrecondition[];
+}
+
+export interface FeatureFileIssueDataTest {
+    key: string;
+    summary: string;
+    tags: string[];
+}
+
+export interface FeatureFileIssueDataPrecondition {
+    key: string;
+    summary: string;
 }
 
 export function getCucumberIssueData(
@@ -189,6 +194,7 @@ export function getCucumberIssueData(
             featureFileIssueKeys.tests.push({
                 key: issueKeys[0],
                 summary: child.scenario.name ? child.scenario.name : "<empty>",
+                tags: child.scenario.tags.map((tag) => tag.name.replace("@", "")),
             });
         } else if (child.background) {
             const preconditionKeys = getCucumberPreconditionIssueTags(
@@ -234,6 +240,10 @@ export function getCucumberIssueData(
                     `)
                 );
             }
+            featureFileIssueKeys.preconditions.push({
+                key: preconditionKeys[0],
+                summary: child.background.name ? child.background.name : "<empty>",
+            });
         }
     }
     return featureFileIssueKeys;

--- a/src/types/xray/requests/importExecutionCucumberMultipartInfo.ts
+++ b/src/types/xray/requests/importExecutionCucumberMultipartInfo.ts
@@ -12,6 +12,7 @@ type CucumberMultipartInfo<IssueTypeDetails, IssueUpdateType> = IssueUpdateType 
         summary: string;
         description?: string;
         issuetype: IssueTypeDetails;
+        labels?: string[];
     };
 };
 export type CucumberMultipartInfoServer = CucumberMultipartInfo<


### PR DESCRIPTION
This PR adds label backups to feature file importing, i.e. a test issue's labels will now always be reset should the import change them.