### PR TITLE
Downgrade typescript from 5.2.2 to 5.1.6

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -11,10 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Node.js 18.x
+      - name: install Node.js 18.x
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: "npm"
       - name: run tests
         run: npm ci && npm test
+        # build plugin to check if it can still be built
+      - name: build plugin
+        run: npm run build

--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -11,13 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: install Node.js 18.x
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: "npm"
-      - name: run tests
+      - name: Run tests
         run: npm ci && npm test
         # build plugin to check if it can still be built
-      - name: build plugin
+      - name: Verify plugin build
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "sinon": "^15.2.0",
                 "sinon-chai": "^3.7.0",
                 "ts-node": "^10.9.1",
-                "typescript": "^5.2.2"
+                "typescript": "^5.1.6"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -7250,9 +7250,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
         "sinon": "^15.2.0",
         "sinon-chai": "^3.7.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.2.2"
+        "typescript": "^5.1.6"
     }
 }


### PR DESCRIPTION
The latest typescript version bump accidentally introduced a build error/regression: https://github.com/microsoft/TypeScript/issues/54695#issuecomment-1698436367

To prevent further unexpected build errors, this PR adds a build step to the test action as well, just to make sure the plugin can always be built.