### PR TITLE
Remove `xray.steps` options

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,8 +32,6 @@ export const ENV_XRAY_STATUS_FAILED = "XRAY_STATUS_FAILED";
 export const ENV_XRAY_STATUS_PASSED = "XRAY_STATUS_PASSED";
 export const ENV_XRAY_STATUS_PENDING = "XRAY_STATUS_PENDING";
 export const ENV_XRAY_STATUS_SKIPPED = "XRAY_STATUS_SKIPPED";
-export const ENV_XRAY_STEPS_MAX_LENGTH_ACTION = "XRAY_STEPS_MAX_LENGTH_ACTION";
-export const ENV_XRAY_STEPS_UPDATE = "XRAY_STEPS_UPDATE";
 export const ENV_XRAY_UPLOAD_RESULTS = "XRAY_UPLOAD_RESULTS";
 export const ENV_XRAY_UPLOAD_SCREENSHOTS = "XRAY_UPLOAD_SCREENSHOTS";
 // ============================================================================================== //

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -92,14 +92,6 @@ describe("the plugin context configuration", () => {
                         expect(options.xray.status.skipped).to.eq(undefined);
                     });
                 });
-                describe("steps", () => {
-                    it("maxLengthAction", () => {
-                        expect(options.xray.steps.maxLengthAction).to.eq(8000);
-                    });
-                    it("update", () => {
-                        expect(options.xray.steps.update).to.eq(false);
-                    });
-                });
                 it("uploadResults", () => {
                     expect(options.xray.uploadResults).to.eq(true);
                 });
@@ -445,42 +437,6 @@ describe("the plugin context configuration", () => {
                     });
                 });
 
-                describe("steps", () => {
-                    it("maxLengthAction", () => {
-                        const options = initOptions(
-                            {},
-                            {
-                                jira: {
-                                    projectKey: "PRJ",
-                                    url: "https://example.org",
-                                },
-                                xray: {
-                                    steps: {
-                                        maxLengthAction: 42,
-                                    },
-                                },
-                            }
-                        );
-                        expect(options.xray.steps.maxLengthAction).to.eq(42);
-                    });
-                    it("update", () => {
-                        const options = initOptions(
-                            {},
-                            {
-                                jira: {
-                                    projectKey: "PRJ",
-                                    url: "https://example.org",
-                                },
-                                xray: {
-                                    steps: {
-                                        update: false,
-                                    },
-                                },
-                            }
-                        );
-                        expect(options.xray.steps.update).to.eq(false);
-                    });
-                });
                 it("uploadResults", () => {
                     const options = initOptions(
                         {},
@@ -857,42 +813,6 @@ describe("the plugin context configuration", () => {
                     expect(options.xray?.status.skipped).to.eq("ski-ba-bop-ba-dop-bop");
                 });
 
-                it("XRAY_STEPS_MAX_LENGTH_ACTION", () => {
-                    const env = {
-                        XRAY_STEPS_MAX_LENGTH_ACTION: "12345",
-                    };
-                    const options = initOptions(env, {
-                        jira: {
-                            projectKey: "CYP",
-                            url: "https://example.org",
-                        },
-                        xray: {
-                            steps: {
-                                maxLengthAction: 500,
-                            },
-                        },
-                    });
-                    expect(options.xray?.steps?.maxLengthAction).to.eq(12345);
-                });
-
-                it("XRAY_STEPS_UPDATE", () => {
-                    const env = {
-                        XRAY_STEPS_UPDATE: "false",
-                    };
-                    const options = initOptions(env, {
-                        jira: {
-                            projectKey: "CYP",
-                            url: "https://example.org",
-                        },
-                        xray: {
-                            steps: {
-                                update: true,
-                            },
-                        },
-                    });
-                    expect(options.xray?.steps?.update).to.be.false;
-                });
-
                 it("XRAY_UPLOAD_RESULTS", () => {
                     const env = {
                         XRAY_UPLOAD_RESULTS: "false",
@@ -1111,40 +1031,6 @@ describe("the plugin context configuration", () => {
                 })
             ).to.throw(
                 "Plugin misconfiguration: test plan issue key ABC-456 does not belong to project CYP"
-            );
-        });
-        it("should not allow step lengths of length zero", async () => {
-            expect(() =>
-                verifyOptions({
-                    jira: {
-                        projectKey: "CYP",
-                        url: "https://example.org",
-                    },
-                    xray: {
-                        steps: {
-                            maxLengthAction: 0,
-                        },
-                    },
-                })
-            ).to.throw(
-                "Plugin misconfiguration: max length of step actions must be a positive number: 0"
-            );
-        });
-        it("should not allow negative step action lengths", async () => {
-            expect(() =>
-                verifyOptions({
-                    jira: {
-                        projectKey: "CYP",
-                        url: "https://example.org",
-                    },
-                    xray: {
-                        steps: {
-                            maxLengthAction: -5,
-                        },
-                    },
-                })
-            ).to.throw(
-                "Plugin misconfiguration: max length of step actions must be a positive number: -5"
             );
         });
     });

--- a/src/context.ts
+++ b/src/context.ts
@@ -36,15 +36,13 @@ import {
     ENV_XRAY_STATUS_PASSED,
     ENV_XRAY_STATUS_PENDING,
     ENV_XRAY_STATUS_SKIPPED,
-    ENV_XRAY_STEPS_MAX_LENGTH_ACTION,
-    ENV_XRAY_STEPS_UPDATE,
     ENV_XRAY_UPLOAD_RESULTS,
     ENV_XRAY_UPLOAD_SCREENSHOTS,
 } from "./constants";
 import { logInfo } from "./logging/logging";
 import { JiraRepositoryCloud } from "./repository/jira/jiraRepositoryCloud";
 import { JiraRepositoryServer } from "./repository/jira/jiraRepositoryServer";
-import { ClientCombination, InternalOptions, Options, XrayStepOptions } from "./types/plugin";
+import { ClientCombination, InternalOptions, Options } from "./types/plugin";
 import { dedent } from "./util/dedent";
 import { asBoolean, asInt, asString, parse } from "./util/parsing";
 
@@ -112,16 +110,6 @@ export function initOptions(env: Cypress.ObjectLike, options: Options): Internal
                 skipped:
                     parse(env, ENV_XRAY_STATUS_SKIPPED, asString) ?? options.xray?.status?.skipped,
             },
-            steps: {
-                maxLengthAction:
-                    parse(env, ENV_XRAY_STEPS_MAX_LENGTH_ACTION, asInt) ??
-                    options.xray?.steps?.maxLengthAction ??
-                    8000,
-                update:
-                    parse(env, ENV_XRAY_STEPS_UPDATE, asBoolean) ??
-                    options.xray?.steps?.update ??
-                    false,
-            },
             uploadResults:
                 parse(env, ENV_XRAY_UPLOAD_RESULTS, asBoolean) ??
                 options.xray?.uploadResults ??
@@ -157,7 +145,6 @@ export function verifyOptions(options: InternalOptions) {
     verifyJiraProjectKey(options.jira.projectKey);
     verifyJiraTestExecutionIssueKey(options.jira.projectKey, options.jira.testExecutionIssueKey);
     verifyJiraTestPlanIssueKey(options.jira.projectKey, options.jira.testPlanIssueKey);
-    verifyXraySteps(options.xray.steps);
 }
 
 function verifyJiraProjectKey(projectKey?: string) {
@@ -178,14 +165,6 @@ function verifyJiraTestPlanIssueKey(projectKey: string, testPlanIssueKey?: strin
     if (testPlanIssueKey && !testPlanIssueKey.startsWith(projectKey)) {
         throw new Error(
             `Plugin misconfiguration: test plan issue key ${testPlanIssueKey} does not belong to project ${projectKey}`
-        );
-    }
-}
-
-function verifyXraySteps(steps: XrayStepOptions) {
-    if (steps.maxLengthAction <= 0) {
-        throw new Error(
-            `Plugin misconfiguration: max length of step actions must be a positive number: ${steps.maxLengthAction}`
         );
     }
 }

--- a/src/conversion/importExecution/importExecutionConverter.spec.ts
+++ b/src/conversion/importExecution/importExecutionConverter.spec.ts
@@ -318,7 +318,6 @@ describe("the import execution converter", () => {
             "CYP-40": "Manual",
             "CYP-41": "Manual",
         };
-        options.xray.steps.update = false;
         const { stubbedWarning } = stubLogging();
         const json = await converter.convert(result, testIssueData);
         expect(json.tests).to.be.an("array").with.length(2);
@@ -344,7 +343,6 @@ describe("the import execution converter", () => {
             "CYP-41": "Manual",
             "CYP-49": "Cucumber",
         };
-        options.xray.steps.update = false;
         const { stubbedWarning } = stubLogging();
         const json = await converter.convert(result, testIssueData);
         expect(json.tests).to.be.an("array").with.length(2);

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -139,23 +139,6 @@ export interface JiraOptions {
     url: string;
 }
 
-export interface XrayStepOptions {
-    /**
-     * The maximum length a step's action description can have in terms of characters. Some Xray
-     * instances might enforce limits on the length and reject step updates in case the action's
-     * description exceeds said limit.
-     */
-    maxLengthAction?: number;
-    /**
-     * Whether to update a manual test issue's test steps during execution results upload. If set
-     * to true, all existing steps ***will be replaced*** with the plugin's steps.
-     *
-     * *Note: the plugin currently creates only one step containing the code of the corresponding
-     * Cypress test function.*
-     */
-    update?: boolean;
-}
-
 export interface XrayOptions {
     /**
      * A mapping of Cypress statuses to corresponding Xray statuses.
@@ -190,10 +173,6 @@ export interface XrayOptions {
          */
         skipped?: string;
     };
-    /**
-     * All options related to manual test issue steps.
-     */
-    steps?: XrayStepOptions;
     /**
      * Turns execution results upload on or off. Useful when switching upload on or off from the
      * command line (via environment variables).


### PR DESCRIPTION
This PR removes all options and environment variables related to `xray.steps`.

Cypress versions 13.0.0 and above do not include any information about the executed test code in the module API anymore. Because the step updates option also was one of the more confusing/problematic options anyways (#50, #169), I have decided to remove it completely. Steps defined in Jira should now not be modified anymore.