### PR TITLE
Switch from Node V16 to Node V18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "typescript": "^5.1.6"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=18.0.0"
             },
             "optionalDependencies": {
                 "@badeball/cypress-cucumber-preprocessor": "^18.0.5"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "build": "tsc --project tsconfigBuild.json && shx cp package.json README.md LICENSE.md CHANGELOG.md dist/"
     },
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "dependencies": {
         "@cucumber/gherkin": "^26.0.3",


### PR DESCRIPTION
With node 16 nearing [the end of its maintenance window](https://nodejs.dev/en/about/releases/), the plugin now requires node version 18 (the current LTS version) or above to be installed.