### PR TITLE
Add Cypress as peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
                 "@typescript-eslint/parser": "^6.7.2",
                 "chai": "^4.3.8",
                 "chai-as-promised": "^7.1.1",
-                "cypress": "^13.2.0",
                 "eslint": "^8.50.0",
                 "mocha": "^10.2.0",
                 "nyc": "^15.1.0",
@@ -42,6 +41,9 @@
             },
             "optionalDependencies": {
                 "@badeball/cypress-cucumber-preprocessor": "^18.0.6"
+            },
+            "peerDependencies": {
+                "cypress": ">=10.0.0 < 14"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -951,7 +953,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
             "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -980,7 +982,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -994,15 +996,15 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "devOptional": true,
+            "peer": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@cypress/xvfb": {
             "version": "1.2.4",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "^3.1.0",
                 "lodash.once": "^4.1.1"
@@ -1010,8 +1012,8 @@
         },
         "node_modules/@cypress/xvfb/node_modules/debug": {
             "version": "3.2.7",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -1887,8 +1889,7 @@
         "node_modules/@types/node": {
             "version": "18.17.17",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.17.tgz",
-            "integrity": "sha512-cOxcXsQ2sxiwkykdJqvyFS+MLQPLvIdwh5l6gNg8qF6s+C7XSkEWOZjK+XhUZd+mYvHV/180g2cnCcIl4l06Pw==",
-            "devOptional": true
+            "integrity": "sha512-cOxcXsQ2sxiwkykdJqvyFS+MLQPLvIdwh5l6gNg8qF6s+C7XSkEWOZjK+XhUZd+mYvHV/180g2cnCcIl4l06Pw=="
         },
         "node_modules/@types/semver": {
             "version": "7.5.2",
@@ -1915,13 +1916,12 @@
         },
         "node_modules/@types/sinonjs__fake-timers": {
             "version": "8.1.1",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@types/sizzle": {
             "version": "2.3.3",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/uuid": {
             "version": "9.0.1",
@@ -1931,6 +1931,7 @@
             "version": "2.10.0",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2154,7 +2155,6 @@
         },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "clean-stack": "^2.0.0",
@@ -2182,16 +2182,16 @@
         },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -2204,7 +2204,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -2254,7 +2253,6 @@
         },
         "node_modules/arch": {
             "version": "2.2.0",
-            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2269,7 +2267,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/archy": {
             "version": "1.0.0",
@@ -2298,14 +2297,13 @@
             "version": "0.2.6",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
             "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "safer-buffer": "~2.1.0"
             }
         },
         "node_modules/assert-plus": {
             "version": "1.0.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8"
@@ -2341,16 +2339,16 @@
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/async": {
             "version": "3.2.4",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -2358,8 +2356,8 @@
         },
         "node_modules/at-least-node": {
             "version": "1.0.0",
-            "devOptional": true,
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -2368,7 +2366,7 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-            "devOptional": true,
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -2377,7 +2375,7 @@
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
             "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/axios": {
             "version": "1.5.0",
@@ -2391,7 +2389,6 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/base64-js": {
@@ -2416,7 +2413,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
@@ -2463,13 +2460,13 @@
         },
         "node_modules/blob-util": {
             "version": "2.0.2",
-            "devOptional": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/bluebird": {
             "version": "3.7.2",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/brace-expansion": {
             "version": "2.0.1",
@@ -2575,8 +2572,8 @@
         },
         "node_modules/cachedir": {
             "version": "2.3.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2622,7 +2619,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
             "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "get-intrinsic": "^1.0.2"
@@ -2681,7 +2678,7 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/chai": {
             "version": "4.3.8",
@@ -2746,8 +2743,8 @@
         },
         "node_modules/check-more-types": {
             "version": "2.24.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -2780,7 +2777,6 @@
         },
         "node_modules/ci-info": {
             "version": "3.8.0",
-            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2788,6 +2784,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2798,7 +2795,6 @@
         },
         "node_modules/clean-stack": {
             "version": "2.2.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -2806,8 +2802,8 @@
         },
         "node_modules/cli-cursor": {
             "version": "3.1.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "restore-cursor": "^3.1.0"
             },
@@ -2829,7 +2825,6 @@
         },
         "node_modules/cli-table3": {
             "version": "0.6.3",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "string-width": "^4.2.0"
@@ -2843,8 +2838,8 @@
         },
         "node_modules/cli-truncate": {
             "version": "2.1.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "slice-ansi": "^3.0.0",
                 "string-width": "^4.2.0"
@@ -2882,8 +2877,8 @@
         },
         "node_modules/colorette": {
             "version": "2.0.19",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/colors": {
             "version": "1.0.3",
@@ -2906,8 +2901,9 @@
         },
         "node_modules/commander": {
             "version": "6.2.1",
-            "devOptional": true,
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -2920,8 +2916,8 @@
         },
         "node_modules/common-tags": {
             "version": "1.8.2",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -2933,7 +2929,6 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/convert-source-map": {
@@ -2970,7 +2965,6 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -2985,8 +2979,8 @@
             "version": "13.2.0",
             "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
             "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
-            "devOptional": true,
             "hasInstallScript": true,
+            "peer": true,
             "dependencies": {
                 "@cypress/request": "^3.0.0",
                 "@cypress/xvfb": "^1.2.4",
@@ -3041,14 +3035,14 @@
         },
         "node_modules/cypress/node_modules/proxy-from-env": {
             "version": "1.0.0",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             },
@@ -3058,12 +3052,11 @@
         },
         "node_modules/dayjs": {
             "version": "1.11.7",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/debug": {
             "version": "4.3.4",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "2.1.2"
@@ -3247,7 +3240,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -3260,7 +3253,6 @@
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/end-of-stream": {
@@ -3272,8 +3264,8 @@
         },
         "node_modules/enquirer": {
             "version": "2.3.6",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1"
             },
@@ -3651,7 +3643,6 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
@@ -3892,13 +3883,13 @@
         },
         "node_modules/eventemitter2": {
             "version": "6.4.7",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/execa": {
             "version": "4.1.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.0",
                 "get-stream": "^5.0.0",
@@ -3919,8 +3910,8 @@
         },
         "node_modules/execa/node_modules/get-stream": {
             "version": "5.2.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pump": "^3.0.0"
             },
@@ -3933,8 +3924,8 @@
         },
         "node_modules/execa/node_modules/is-stream": {
             "version": "2.0.1",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -3944,8 +3935,8 @@
         },
         "node_modules/executable": {
             "version": "4.1.1",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pify": "^2.2.0"
             },
@@ -3957,12 +3948,12 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/extract-zip": {
             "version": "2.0.1",
-            "devOptional": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "debug": "^4.1.1",
                 "get-stream": "^5.1.0",
@@ -3980,8 +3971,8 @@
         },
         "node_modules/extract-zip/node_modules/get-stream": {
             "version": "5.2.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pump": "^3.0.0"
             },
@@ -3994,7 +3985,6 @@
         },
         "node_modules/extsprintf": {
             "version": "1.3.0",
-            "devOptional": true,
             "engines": [
                 "node >=0.6.0"
             ],
@@ -4049,7 +4039,6 @@
         },
         "node_modules/figures": {
             "version": "3.2.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "escape-string-regexp": "^1.0.5"
@@ -4203,7 +4192,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-            "devOptional": true,
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -4245,8 +4234,8 @@
         },
         "node_modules/fs-extra": {
             "version": "9.1.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
@@ -4259,12 +4248,10 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
-            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.1",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/gensync": {
@@ -4295,7 +4282,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
             "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
@@ -4327,8 +4314,8 @@
         },
         "node_modules/getos": {
             "version": "3.2.1",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "async": "^3.2.0"
             }
@@ -4337,14 +4324,13 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             }
         },
         "node_modules/glob": {
             "version": "7.2.0",
-            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -4374,7 +4360,6 @@
         },
         "node_modules/glob/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -4383,7 +4368,6 @@
         },
         "node_modules/glob/node_modules/minimatch": {
             "version": "3.1.2",
-            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -4394,7 +4378,6 @@
         },
         "node_modules/global-dirs": {
             "version": "3.0.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "ini": "2.0.0"
@@ -4444,7 +4427,6 @@
         },
         "node_modules/has": {
             "version": "1.0.3",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.1"
@@ -4485,7 +4467,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
             "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-            "devOptional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -4497,7 +4479,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
             "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "devOptional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -4556,7 +4538,7 @@
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
             "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^2.0.2",
@@ -4568,8 +4550,8 @@
         },
         "node_modules/human-signals": {
             "version": "1.1.1",
-            "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.12.0"
             }
@@ -4633,7 +4615,6 @@
         },
         "node_modules/indent-string": {
             "version": "4.0.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4641,7 +4622,6 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
-            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
@@ -4654,7 +4634,6 @@
         },
         "node_modules/ini": {
             "version": "2.0.0",
-            "devOptional": true,
             "license": "ISC",
             "engines": {
                 "node": ">=10"
@@ -4687,8 +4666,8 @@
         },
         "node_modules/is-ci": {
             "version": "3.0.1",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ci-info": "^3.2.0"
             },
@@ -4717,7 +4696,6 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4736,7 +4714,6 @@
         },
         "node_modules/is-installed-globally": {
             "version": "0.4.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "global-dirs": "^3.0.0",
@@ -4763,7 +4740,6 @@
         },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4786,12 +4762,10 @@
         },
         "node_modules/is-typedarray": {
             "version": "1.0.0",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -4814,14 +4788,13 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.0",
@@ -5010,7 +4983,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/jsesc": {
             "version": "2.5.2",
@@ -5033,7 +5006,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
             "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -5050,7 +5023,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -5065,8 +5038,8 @@
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "universalify": "^2.0.0"
             },
@@ -5078,10 +5051,10 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
             "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
-            "devOptional": true,
             "engines": [
                 "node >=0.6.0"
             ],
+            "peer": true,
             "dependencies": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -5105,8 +5078,8 @@
         },
         "node_modules/lazy-ass": {
             "version": "1.6.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "> 0.8"
             }
@@ -5131,8 +5104,8 @@
         },
         "node_modules/listr2": {
             "version": "3.14.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cli-truncate": "^2.1.0",
                 "colorette": "^2.0.16",
@@ -5171,7 +5144,6 @@
         },
         "node_modules/lodash": {
             "version": "4.17.21",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/lodash-es": {
@@ -5203,12 +5175,11 @@
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.0",
@@ -5223,8 +5194,8 @@
         },
         "node_modules/log-update": {
             "version": "4.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-escapes": "^4.3.0",
                 "cli-cursor": "^3.1.0",
@@ -5240,8 +5211,8 @@
         },
         "node_modules/log-update/node_modules/slice-ansi": {
             "version": "4.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -5256,8 +5227,8 @@
         },
         "node_modules/log-update/node_modules/wrap-ansi": {
             "version": "6.2.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -5330,8 +5301,8 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -5372,8 +5343,8 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5391,7 +5362,6 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "devOptional": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5486,7 +5456,6 @@
         },
         "node_modules/ms": {
             "version": "2.1.2",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/mz": {
@@ -5584,8 +5553,8 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -5795,7 +5764,7 @@
             "version": "1.12.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
             "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-            "devOptional": true,
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -5809,8 +5778,8 @@
         },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -5839,8 +5808,8 @@
         },
         "node_modules/ospath": {
             "version": "1.2.2",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
@@ -5872,8 +5841,8 @@
         },
         "node_modules/p-map": {
             "version": "4.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "aggregate-error": "^3.0.0"
             },
@@ -5957,7 +5926,6 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -5965,7 +5933,6 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6038,7 +6005,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/picocolors": {
             "version": "1.0.0",
@@ -6149,8 +6116,8 @@
         },
         "node_modules/pretty-bytes": {
             "version": "5.6.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -6162,7 +6129,7 @@
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
             "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-            "devOptional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -6205,12 +6172,12 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
             "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/pump": {
             "version": "3.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -6218,7 +6185,6 @@
         },
         "node_modules/punycode": {
             "version": "2.3.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -6228,7 +6194,7 @@
             "version": "6.10.4",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
             "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "side-channel": "^1.0.4"
             },
@@ -6243,7 +6209,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
             "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -6343,8 +6309,8 @@
         },
         "node_modules/request-progress": {
             "version": "3.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "throttleit": "^1.0.0"
             }
@@ -6366,7 +6332,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/resolve": {
             "version": "1.22.1",
@@ -6406,8 +6372,8 @@
         },
         "node_modules/restore-cursor": {
             "version": "3.1.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "onetime": "^5.1.0",
                 "signal-exit": "^3.0.2"
@@ -6427,12 +6393,11 @@
         },
         "node_modules/rfdc": {
             "version": "1.3.0",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
-            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^7.1.3"
@@ -6468,15 +6433,14 @@
         },
         "node_modules/rxjs": {
             "version": "7.8.0",
-            "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
-            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -6497,7 +6461,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/seed-random": {
             "version": "2.2.0",
@@ -6565,7 +6529,6 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -6576,7 +6539,6 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6617,7 +6579,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
             "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.0",
                 "get-intrinsic": "^1.0.2",
@@ -6629,7 +6591,6 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/sinon": {
@@ -6688,8 +6649,8 @@
         },
         "node_modules/slice-ansi": {
             "version": "3.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -6777,7 +6738,7 @@
             "version": "1.17.0",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
             "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -6815,7 +6776,6 @@
         },
         "node_modules/string-width": {
             "version": "4.2.3",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -6843,7 +6803,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -6882,8 +6841,8 @@
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6901,7 +6860,6 @@
         },
         "node_modules/supports-color": {
             "version": "8.1.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -7025,8 +6983,8 @@
         },
         "node_modules/throttleit": {
             "version": "1.0.0",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/through": {
             "version": "2.3.8",
@@ -7034,7 +6992,6 @@
         },
         "node_modules/tmp": {
             "version": "0.2.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "rimraf": "^3.0.0"
@@ -7076,7 +7033,7 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
             "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -7091,7 +7048,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-            "devOptional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -7169,14 +7126,13 @@
         },
         "node_modules/tslib": {
             "version": "2.5.0",
-            "devOptional": true,
             "license": "0BSD"
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -7188,7 +7144,7 @@
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-            "devOptional": true
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -7211,8 +7167,8 @@
         },
         "node_modules/type-fest": {
             "version": "0.21.3",
-            "devOptional": true,
             "license": "(MIT OR CC0-1.0)",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -7251,16 +7207,16 @@
         },
         "node_modules/universalify": {
             "version": "2.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             }
         },
         "node_modules/untildify": {
             "version": "4.0.0",
-            "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7316,7 +7272,7 @@
             "version": "1.5.10",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-            "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -7346,7 +7302,6 @@
         },
         "node_modules/verror": {
             "version": "1.10.0",
-            "devOptional": true,
             "engines": [
                 "node >=0.6.0"
             ],
@@ -7359,7 +7314,6 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -7383,7 +7337,6 @@
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
         "form-data": "^4.0.0",
         "semver": "^7.5.4"
     },
+    "peerDependencies": {
+        "cypress": ">=10.0.0 < 14"
+    },
     "optionalDependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^18.0.6"
     },
@@ -63,7 +66,6 @@
         "@typescript-eslint/parser": "^6.7.2",
         "chai": "^4.3.8",
         "chai-as-promised": "^7.1.1",
-        "cypress": "^13.2.0",
         "eslint": "^8.50.0",
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",


### PR DESCRIPTION
This PR moves Cypress to npm's [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies), resulting in explicit version compatibility checks during installation.