### PR TITLE
Fix field ID hints in error messages

### DIFF
--- a/src/repository/jira/jiraRepository.ts
+++ b/src/repository/jira/jiraRepository.ts
@@ -72,32 +72,29 @@ export abstract class JiraRepository<
                 throw new Error(`Failed to fetch Jira field ID for field with name: ${fieldName}`);
             },
             onMultipleFieldsError: (duplicates: FieldDetailServer[] | FieldDetailCloud[]) => {
+                const nameDuplicates = duplicates
+                    .map((field: FieldDetailServer | FieldDetailCloud) =>
+                        Object.entries(field)
+                            .map(([key, value]) => `${key}: ${value}`)
+                            .join(", ")
+                    )
+                    .join("\n");
+                const idSuggestions = duplicates
+                    .map((field: FieldDetailServer | FieldDetailCloud) => `"${field.id}"`)
+                    .join(" or ");
                 throw new Error(
                     dedent(`
                         Failed to fetch Jira field ID for field with name: ${fieldName}
                         There are multiple fields with this name
 
                         Duplicates:
-                          ${duplicates
-                              .map((field: FieldDetailServer | FieldDetailCloud) =>
-                                  Object.entries(field)
-                                      .map(([key, value]) => `${key}: ${value}`)
-                                      .join(", ")
-                              )
-                              .join("\n")}
+                          ${nameDuplicates}
 
                         You can provide field IDs in the options:
 
                           jira: {
-                            fields = {
-                              ${optionName}: {
-                                id: // ${duplicates
-                                    .map(
-                                        (field: FieldDetailServer | FieldDetailCloud) =>
-                                            `"${field.id}"`
-                                    )
-                                    .join(" or ")}
-                              }
+                            fields: {
+                              ${optionName}: <id> // ${idSuggestions}
                             }
                           }
                     `)
@@ -113,10 +110,8 @@ export abstract class JiraRepository<
                             You can provide field IDs directly without relying on language settings:
 
                               jira: {
-                                fields = {
-                                  ${optionName}: {
-                                    id: // corresponding field ID
-                                  }
+                                fields: {
+                                  ${optionName}: <id> // corresponding field ID
                                 }
                               }
                         `)
@@ -133,10 +128,8 @@ export abstract class JiraRepository<
                             You can provide field IDs directly without relying on language settings:
 
                               jira: {
-                                fields = {
-                                  ${optionName}: {
-                                    id: // corresponding field ID
-                                  }
+                                fields: {
+                                  ${optionName}: <id> // corresponding field ID
                                 }
                               }
                         `)

--- a/src/repository/jira/jiraRepositoryCloud.spec.ts
+++ b/src/repository/jira/jiraRepositoryCloud.spec.ts
@@ -215,10 +215,8 @@ describe("the cloud issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          summary: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          summary: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -274,10 +272,8 @@ describe("the cloud issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          summary: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          summary: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -333,10 +329,8 @@ describe("the cloud issue repository", () => {
                     You can provide field IDs in the options:
 
                       jira: {
-                        fields = {
-                          summary: {
-                            id: // "summary" or "customfield_12345"
-                          }
+                        fields: {
+                          summary: <id> // "summary" or "customfield_12345"
                         }
                       }
                 `)
@@ -606,10 +600,8 @@ describe("the cloud issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          description: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          description: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -665,10 +657,8 @@ describe("the cloud issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          description: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          description: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -724,10 +714,8 @@ describe("the cloud issue repository", () => {
                     You can provide field IDs in the options:
 
                       jira: {
-                        fields = {
-                          description: {
-                            id: // "description" or "customfield_12345"
-                          }
+                        fields: {
+                          description: <id> // "description" or "customfield_12345"
                         }
                       }
                 `)
@@ -1091,10 +1079,8 @@ describe("the cloud issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          labels: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          labels: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -1150,10 +1136,8 @@ describe("the cloud issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          labels: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          labels: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -1209,10 +1193,8 @@ describe("the cloud issue repository", () => {
                     You can provide field IDs in the options:
 
                       jira: {
-                        fields = {
-                          labels: {
-                            id: // "labels" or "customfield_12345"
-                          }
+                        fields: {
+                          labels: <id> // "labels" or "customfield_12345"
                         }
                       }
                 `)

--- a/src/repository/jira/jiraRepositoryServer.spec.ts
+++ b/src/repository/jira/jiraRepositoryServer.spec.ts
@@ -216,10 +216,8 @@ describe("the server issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          summary: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          summary: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -273,10 +271,8 @@ describe("the server issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          summary: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          summary: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -330,10 +326,8 @@ describe("the server issue repository", () => {
                     You can provide field IDs in the options:
 
                       jira: {
-                        fields = {
-                          summary: {
-                            id: // "summary" or "customfield_12345"
-                          }
+                        fields: {
+                          summary: <id> // "summary" or "customfield_12345"
                         }
                       }
                 `)
@@ -611,10 +605,8 @@ describe("the server issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          description: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          description: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -668,10 +660,8 @@ describe("the server issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          description: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          description: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -725,10 +715,8 @@ describe("the server issue repository", () => {
                     You can provide field IDs in the options:
 
                       jira: {
-                        fields = {
-                          description: {
-                            id: // "description" or "customfield_12345"
-                          }
+                        fields: {
+                          description: <id> // "description" or "customfield_12345"
                         }
                       }
                 `)
@@ -1075,10 +1063,8 @@ describe("the server issue repository", () => {
                     You can provide field IDs in the options:
 
                       jira: {
-                        fields = {
-                          testType: {
-                            id: // "test_type" or "customfield_12345"
-                          }
+                        fields: {
+                          testType: <id> // "test_type" or "customfield_12345"
                         }
                       }
                 `)
@@ -1101,10 +1087,8 @@ describe("the server issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          testType: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          testType: <id> // corresponding field ID
                         }
                       }
                 `)
@@ -1158,10 +1142,8 @@ describe("the server issue repository", () => {
                     You can provide field IDs directly without relying on language settings:
 
                       jira: {
-                        fields = {
-                          testType: {
-                            id: // corresponding field ID
-                          }
+                        fields: {
+                          testType: <id> // corresponding field ID
                         }
                       }
                 `)


### PR DESCRIPTION
When fetching field IDs, the suggestions contained within the error messages were invalid Typescript and did not match the actual option structure:

```ts
// Before
{
  jira: {
    fields = {
      summary: {
        id: // corresponding field ID
      }
    }
  }
}
```

```ts
// After
{
  jira: {
    fields: {
      summary: <id> // corresponding field ID
    }
  }
}
```

