### PR TITLE
Remove unnecessary test info updates

### DIFF
--- a/src/conversion/importExecution/importExecutionConverter.ts
+++ b/src/conversion/importExecution/importExecutionConverter.ts
@@ -25,7 +25,7 @@ type XrayTestType = XrayTestServer | XrayTestCloud;
 export class ImportExecutionConverter extends Converter<
     CypressRunResultType,
     XrayTestExecutionResults<XrayTestType>,
-    TestIssueData
+    never
 > {
     /**
      * Whether the converter is a cloud converter. Useful for automatically deducing which test
@@ -48,8 +48,7 @@ export class ImportExecutionConverter extends Converter<
     }
 
     public async convert(
-        results: CypressRunResultType,
-        issueData: TestIssueData
+        results: CypressRunResultType
     ): Promise<XrayTestExecutionResults<XrayTestType>> {
         let testConverter: TestConverter<XrayTestType>;
         if (this.isCloudConverter) {
@@ -67,7 +66,7 @@ export class ImportExecutionConverter extends Converter<
                 summary: this.getTextExecutionResultSummary(results),
                 testPlanKey: this.options.jira.testPlanIssueKey,
             },
-            tests: await testConverter.convert(results, issueData),
+            tests: await testConverter.convert(results),
         };
     }
 

--- a/src/conversion/importExecution/testConverter.spec.ts
+++ b/src/conversion/importExecution/testConverter.spec.ts
@@ -13,14 +13,12 @@ import { CypressRunResult as CypressRunResult_V12 } from "../../types/cypress/12
 import { CypressRunResult as CypressRunResult_V13 } from "../../types/cypress/13.0.0/api";
 import { InternalOptions } from "../../types/plugin";
 import { dedent } from "../../util/dedent";
-import { TestIssueData } from "./importExecutionConverter";
 import { TestConverterCloud } from "./testConverterCloud";
 
 chai.use(chaiAsPromised);
 
 describe("the test converter", () => {
     let options: InternalOptions;
-    let testIssueData: TestIssueData;
     beforeEach(() => {
         options = {
             jira: initJiraOptions(
@@ -39,30 +37,15 @@ describe("the test converter", () => {
             plugin: initPluginOptions({}, {}),
             openSSL: initOpenSSLOptions({}, {}),
         };
-        testIssueData = { summaries: {}, testTypes: {} };
     });
 
     it("warns about skipped screenshots", async () => {
         const result: CypressRunResult_V13 = JSON.parse(
             readFileSync("./test/resources/runResult_13_0_0_manualScreenshot.json", "utf-8")
         );
-        testIssueData.summaries = {
-            "CYP-452": "This is",
-            "CYP-268": "a distributed",
-            "CYP-237": "summary",
-            "CYP-332": "part 4",
-            "CYP-333": "part 5",
-        };
-        testIssueData.testTypes = {
-            "CYP-452": "Generic",
-            "CYP-268": "Manual",
-            "CYP-237": "Cucumber",
-            "CYP-332": "Manual",
-            "CYP-333": "Manual",
-        };
         const converter = new TestConverterCloud(options);
         const { stubbedWarning } = stubLogging();
-        const json = await converter.convert(result, testIssueData);
+        const json = await converter.convert(result);
         expect(stubbedWarning).to.have.been.calledOnceWithExactly(
             dedent(`
                 Screenshot will not be uploaded: ./test/resources/small.png
@@ -96,7 +79,7 @@ describe("the test converter", () => {
             { featureFileExtension: ".feature" }
         );
         const converter = new TestConverterCloud(options);
-        await expect(converter.convert(result, testIssueData)).to.eventually.be.rejectedWith(
+        await expect(converter.convert(result)).to.eventually.be.rejectedWith(
             "Failed to extract test run data: Only Cucumber tests were executed"
         );
     });
@@ -117,7 +100,7 @@ describe("the test converter", () => {
             { featureFileExtension: ".ts" }
         );
         const converter = new TestConverterCloud(options);
-        await expect(converter.convert(result, testIssueData)).to.eventually.be.rejectedWith(
+        await expect(converter.convert(result)).to.eventually.be.rejectedWith(
             "Failed to extract test run data: Only Cucumber tests were executed"
         );
     });

--- a/src/conversion/importExecution/testConverter.ts
+++ b/src/conversion/importExecution/testConverter.ts
@@ -32,8 +32,7 @@ export abstract class TestConverter<
     TestIssueData
 > {
     public async convert(
-        runResults: CypressRunResult_V12 | CypressRunResult_V13,
-        issueData?: TestIssueData
+        runResults: CypressRunResult_V12 | CypressRunResult_V13
     ): Promise<[XrayTestType, ...XrayTestType[]]> {
         const testRunData = await this.getTestRunData(runResults);
         const xrayTests: XrayTestType[] = [];
@@ -43,19 +42,9 @@ export abstract class TestConverter<
                     testData.title,
                     this.options.jira.projectKey
                 );
-                if (!issueData?.summaries[issueKey]) {
-                    throw new Error(`Summary of corresponding issue is unknown: ${issueKey}`);
-                }
-                if (!issueData?.testTypes[issueKey]) {
-                    throw new Error(`Test type of corresponding issue is unknown: ${issueKey}`);
-                }
                 const test: XrayTestType = this.getTest(
                     testData,
                     issueKey,
-                    {
-                        summary: issueData.summaries[issueKey],
-                        testType: issueData.testTypes[issueKey],
-                    },
                     this.getXrayEvidence(testData)
                 );
                 xrayTests.push(test);
@@ -80,10 +69,6 @@ export abstract class TestConverter<
     protected abstract getTest(
         test: ITestRunData,
         issueKey: string,
-        issueData: {
-            summary: string;
-            testType: string;
-        },
         evidence: XrayEvidenceItem[]
     ): XrayTestType;
 

--- a/src/conversion/importExecution/testConverterCloud.spec.ts
+++ b/src/conversion/importExecution/testConverterCloud.spec.ts
@@ -8,12 +8,10 @@ import {
 } from "../../context";
 import { CypressRunResult } from "../../types/cypress/12.0.0/api";
 import { InternalOptions } from "../../types/plugin";
-import { TestIssueData } from "./importExecutionConverter";
 import { TestConverterCloud } from "./testConverterCloud";
 
 describe("the test converter cloud", () => {
     let options: InternalOptions;
-    let testIssueData: TestIssueData;
     beforeEach(() => {
         options = {
             jira: initJiraOptions(
@@ -32,55 +30,29 @@ describe("the test converter cloud", () => {
             plugin: initPluginOptions({}, {}),
             openSSL: initOpenSSLOptions({}, {}),
         };
-        testIssueData = { summaries: {}, testTypes: {} };
     });
 
     it("converts run results for Cypress <13.0.0", async () => {
         const result: CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        testIssueData.summaries = {
-            "CYP-40": "This is",
-            "CYP-41": "a distributed",
-            "CYP-49": "summary",
-        };
-        testIssueData.testTypes = {
-            "CYP-40": "Generic",
-            "CYP-41": "Manual",
-            "CYP-49": "Cucumber",
-        };
         const converter = new TestConverterCloud(options);
-        const json = await converter.convert(result, testIssueData);
+        const json = await converter.convert(result);
         expect(json).to.deep.eq([
             {
                 testKey: "CYP-40",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "This is",
-                    type: "Generic",
-                },
                 start: "2022-11-28T17:41:15Z",
                 finish: "2022-11-28T17:41:15Z",
                 status: "PASSED",
             },
             {
                 testKey: "CYP-41",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "a distributed",
-                    type: "Manual",
-                },
                 start: "2022-11-28T17:41:15Z",
                 finish: "2022-11-28T17:41:15Z",
                 status: "PASSED",
             },
             {
                 testKey: "CYP-49",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "summary",
-                    type: "Cucumber",
-                },
                 start: "2022-11-28T17:41:15Z",
                 finish: "2022-11-28T17:41:19Z",
                 status: "FAILED",
@@ -98,52 +70,23 @@ describe("the test converter cloud", () => {
         const result: CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResult_13_0_0.json", "utf-8")
         );
-        testIssueData.summaries = {
-            "CYP-452": "This is",
-            "CYP-268": "a distributed",
-            "CYP-237": "summary",
-            "CYP-332": "part 4",
-            "CYP-333": "part 5",
-        };
-        testIssueData.testTypes = {
-            "CYP-452": "Generic",
-            "CYP-268": "Manual",
-            "CYP-237": "Cucumber",
-            "CYP-332": "Manual",
-            "CYP-333": "Manual",
-        };
         const converter = new TestConverterCloud(options);
-        const json = await converter.convert(result, testIssueData);
+        const json = await converter.convert(result);
         expect(json).to.deep.eq([
             {
                 testKey: "CYP-452",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "This is",
-                    type: "Generic",
-                },
                 start: "2023-09-09T10:59:28Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "PASSED",
             },
             {
                 testKey: "CYP-268",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "a distributed",
-                    type: "Manual",
-                },
                 start: "2023-09-09T10:59:29Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "PASSED",
             },
             {
                 testKey: "CYP-237",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "summary",
-                    type: "Cucumber",
-                },
                 start: "2023-09-09T10:59:29Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "FAILED",
@@ -156,22 +99,12 @@ describe("the test converter cloud", () => {
             },
             {
                 testKey: "CYP-332",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "part 4",
-                    type: "Manual",
-                },
                 start: "2023-09-09T10:59:29Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "FAILED",
             },
             {
                 testKey: "CYP-333",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "part 5",
-                    type: "Manual",
-                },
                 start: "2023-09-09T10:59:29Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "TODO",

--- a/src/conversion/importExecution/testConverterCloud.ts
+++ b/src/conversion/importExecution/testConverterCloud.ts
@@ -8,20 +8,11 @@ export class TestConverterCloud extends TestConverter<XrayTestCloud> {
     protected getTest(
         test: ITestRunData,
         issueKey: string,
-        issueData: {
-            summary: string;
-            testType: string;
-        },
         evidence: XrayEvidenceItem[]
     ): XrayTestCloud {
         // TODO: Support multiple iterations.
         const xrayTest: XrayTestCloud = {
             testKey: issueKey,
-            testInfo: {
-                projectKey: this.options.jira.projectKey,
-                summary: issueData.summary,
-                type: issueData.testType,
-            },
             start: truncateISOTime(test.startedAt.toISOString()),
             finish: truncateISOTime(
                 new Date(test.startedAt.getTime() + test.duration).toISOString()

--- a/src/conversion/importExecution/testConverterServer.spec.ts
+++ b/src/conversion/importExecution/testConverterServer.spec.ts
@@ -8,12 +8,10 @@ import {
 } from "../../context";
 import { CypressRunResult } from "../../types/cypress/12.0.0/api";
 import { InternalOptions } from "../../types/plugin";
-import { TestIssueData } from "./importExecutionConverter";
 import { TestConverterServer } from "./testConverterServer";
 
 describe("the test converter server", () => {
     let options: InternalOptions;
-    let testIssueData: TestIssueData;
     beforeEach(() => {
         options = {
             jira: initJiraOptions(
@@ -32,55 +30,29 @@ describe("the test converter server", () => {
             plugin: initPluginOptions({}, {}),
             openSSL: initOpenSSLOptions({}, {}),
         };
-        testIssueData = { summaries: {}, testTypes: {} };
     });
 
     it("converts run results for Cypress <13.0.0", async () => {
         const result: CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        testIssueData.summaries = {
-            "CYP-40": "This is",
-            "CYP-41": "a distributed",
-            "CYP-49": "summary",
-        };
-        testIssueData.testTypes = {
-            "CYP-40": "Generic",
-            "CYP-41": "Manual",
-            "CYP-49": "Cucumber",
-        };
         const converter = new TestConverterServer(options);
-        const json = await converter.convert(result, testIssueData);
+        const json = await converter.convert(result);
         expect(json).to.deep.eq([
             {
                 testKey: "CYP-40",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "This is",
-                    testType: "Generic",
-                },
                 start: "2022-11-28T17:41:15Z",
                 finish: "2022-11-28T17:41:15Z",
                 status: "PASS",
             },
             {
                 testKey: "CYP-41",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "a distributed",
-                    testType: "Manual",
-                },
                 start: "2022-11-28T17:41:15Z",
                 finish: "2022-11-28T17:41:15Z",
                 status: "PASS",
             },
             {
                 testKey: "CYP-49",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "summary",
-                    testType: "Cucumber",
-                },
                 start: "2022-11-28T17:41:15Z",
                 finish: "2022-11-28T17:41:19Z",
                 status: "FAIL",
@@ -98,52 +70,23 @@ describe("the test converter server", () => {
         const result: CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResult_13_0_0.json", "utf-8")
         );
-        testIssueData.summaries = {
-            "CYP-452": "This is",
-            "CYP-268": "a distributed",
-            "CYP-237": "summary",
-            "CYP-332": "part 4",
-            "CYP-333": "part 5",
-        };
-        testIssueData.testTypes = {
-            "CYP-452": "Generic",
-            "CYP-268": "Manual",
-            "CYP-237": "Cucumber",
-            "CYP-332": "Manual",
-            "CYP-333": "Manual",
-        };
         const converter = new TestConverterServer(options);
-        const json = await converter.convert(result, testIssueData);
+        const json = await converter.convert(result);
         expect(json).to.deep.eq([
             {
                 testKey: "CYP-452",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "This is",
-                    testType: "Generic",
-                },
                 start: "2023-09-09T10:59:28Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "PASS",
             },
             {
                 testKey: "CYP-268",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "a distributed",
-                    testType: "Manual",
-                },
                 start: "2023-09-09T10:59:29Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "PASS",
             },
             {
                 testKey: "CYP-237",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "summary",
-                    testType: "Cucumber",
-                },
                 start: "2023-09-09T10:59:29Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "FAIL",
@@ -156,22 +99,12 @@ describe("the test converter server", () => {
             },
             {
                 testKey: "CYP-332",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "part 4",
-                    testType: "Manual",
-                },
                 start: "2023-09-09T10:59:29Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "FAIL",
             },
             {
                 testKey: "CYP-333",
-                testInfo: {
-                    projectKey: "CYP",
-                    summary: "part 5",
-                    testType: "Manual",
-                },
                 start: "2023-09-09T10:59:29Z",
                 finish: "2023-09-09T10:59:29Z",
                 status: "TODO",

--- a/src/conversion/importExecution/testConverterServer.ts
+++ b/src/conversion/importExecution/testConverterServer.ts
@@ -8,20 +8,11 @@ export class TestConverterServer extends TestConverter<XrayTestServer> {
     protected getTest(
         test: ITestRunData,
         issueKey: string,
-        issueData: {
-            summary: string;
-            testType: string;
-        },
         evidence: XrayEvidenceItem[]
     ): XrayTestServer {
         // TODO: Support multiple iterations.
         const xrayTest: XrayTestServer = {
             testKey: issueKey,
-            testInfo: {
-                projectKey: this.options.jira.projectKey,
-                summary: issueData.summary,
-                testType: issueData.testType,
-            },
             start: truncateISOTime(test.startedAt.toISOString()),
             finish: truncateISOTime(
                 new Date(test.startedAt.getTime() + test.duration).toISOString()

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -11,7 +11,6 @@ import {
     containsCucumberTest,
     containsNativeTest,
     getCucumberIssueData,
-    getNativeTestIssueKeys,
 } from "./preprocessing/preprocessing";
 import { JiraRepositoryCloud } from "./repository/jira/jiraRepositoryCloud";
 import { JiraRepositoryServer } from "./repository/jira/jiraRepositoryServer";
@@ -176,19 +175,9 @@ async function uploadCypressResults(
     options: InternalOptions,
     clients: ClientCombination
 ) {
-    const issueKeys = getNativeTestIssueKeys(
-        runResult,
-        options.jira.projectKey,
-        options.cucumber?.featureFileExtension
-    );
-    const issueSummaries = await clients.jiraRepository.getSummaries(...issueKeys);
-    const issueTestTypes = await clients.jiraRepository.getTestTypes(...issueKeys);
     const converter = new ImportExecutionConverter(options, clients.kind === "cloud");
     try {
-        const cypressExecution = await converter.convert(runResult, {
-            summaries: issueSummaries,
-            testTypes: issueTestTypes,
-        });
+        const cypressExecution = await converter.convert(runResult);
         return await clients.xrayClient.importExecution(cypressExecution);
     } catch (error: unknown) {
         logError(errorMessage(error));


### PR DESCRIPTION
Addresses #209, #210.

This PR prevents test execution imports from changing existing test information altogether, including data such as:
- summaries
- test types
- requirement keys
- labels
- generic test definitions
- test steps
- BDD scenarios
