### PR TITLE
Clean up Jira repositories

### DIFF
--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -1041,8 +1041,12 @@ describe("the plugin context configuration", () => {
             const { jiraClient, xrayClient } = await initClients(jiraOptions, env);
             expect(jiraClient).to.be.an.instanceof(JiraClientCloud);
             expect(xrayClient).to.be.an.instanceof(XrayClientCloud);
-            expect(jiraClient.getCredentials()).to.be.an.instanceof(BasicAuthCredentials);
-            expect(xrayClient.getCredentials()).to.be.an.instanceof(JWTCredentials);
+            expect((jiraClient as JiraClientCloud).getCredentials()).to.be.an.instanceof(
+                BasicAuthCredentials
+            );
+            expect((xrayClient as XrayClientCloud).getCredentials()).to.be.an.instanceof(
+                JWTCredentials
+            );
             expect(stubbedInfo).to.have.been.calledWith(
                 "Jira username and API token found. Setting up Jira cloud basic auth credentials"
             );
@@ -1084,8 +1088,12 @@ describe("the plugin context configuration", () => {
             const { jiraClient, xrayClient } = await initClients(jiraOptions, env);
             expect(jiraClient).to.be.an.instanceof(JiraClientServer);
             expect(xrayClient).to.be.an.instanceof(XrayClientServer);
-            expect(jiraClient.getCredentials()).to.be.an.instanceof(PATCredentials);
-            expect(xrayClient.getCredentials()).to.be.an.instanceof(PATCredentials);
+            expect((jiraClient as JiraClientServer).getCredentials()).to.be.an.instanceof(
+                PATCredentials
+            );
+            expect((xrayClient as XrayClientServer).getCredentials()).to.be.an.instanceof(
+                PATCredentials
+            );
             expect(stubbedInfo).to.have.been.calledWith(
                 "Jira PAT found. Setting up Jira server PAT credentials"
             );
@@ -1109,8 +1117,12 @@ describe("the plugin context configuration", () => {
             const { jiraClient, xrayClient } = await initClients(jiraOptions, env);
             expect(jiraClient).to.be.an.instanceof(JiraClientServer);
             expect(xrayClient).to.be.an.instanceof(XrayClientServer);
-            expect(jiraClient.getCredentials()).to.be.an.instanceof(BasicAuthCredentials);
-            expect(xrayClient.getCredentials()).to.be.an.instanceof(BasicAuthCredentials);
+            expect((jiraClient as JiraClientServer).getCredentials()).to.be.an.instanceof(
+                BasicAuthCredentials
+            );
+            expect((xrayClient as XrayClientServer).getCredentials()).to.be.an.instanceof(
+                BasicAuthCredentials
+            );
             expect(stubbedInfo).to.have.been.calledWith(
                 "Jira username and password found. Setting up Jira server basic auth credentials"
             );
@@ -1137,8 +1149,12 @@ describe("the plugin context configuration", () => {
             const { jiraClient, xrayClient } = await initClients(jiraOptions, env);
             expect(jiraClient).to.be.an.instanceof(JiraClientCloud);
             expect(xrayClient).to.be.an.instanceof(XrayClientCloud);
-            expect(jiraClient.getCredentials()).to.be.an.instanceof(BasicAuthCredentials);
-            expect(xrayClient.getCredentials()).to.be.an.instanceof(JWTCredentials);
+            expect((jiraClient as JiraClientCloud).getCredentials()).to.be.an.instanceof(
+                BasicAuthCredentials
+            );
+            expect((xrayClient as XrayClientCloud).getCredentials()).to.be.an.instanceof(
+                JWTCredentials
+            );
         });
         it("should throw an error for missing jira urls", async () => {
             jiraOptions.url = undefined as unknown as string;

--- a/src/context.ts
+++ b/src/context.ts
@@ -47,9 +47,9 @@ import {
     importOptionalDependency,
 } from "./dependencies";
 import { logDebug, logInfo } from "./logging/logging";
-import { JiraFieldRepository } from "./repository/jira/fields/jiraFieldRepository";
+import { CachingJiraFieldRepository } from "./repository/jira/fields/jiraFieldRepository";
 import { JiraIssueFetcher, JiraIssueFetcherCloud } from "./repository/jira/fields/jiraIssueFetcher";
-import { JiraRepository } from "./repository/jira/jiraRepository";
+import { CachingJiraRepository } from "./repository/jira/jiraRepository";
 import {
     ClientCombination,
     InternalCucumberOptions,
@@ -334,7 +334,7 @@ export async function initClients(
             );
             await pingXrayCloud(xrayCredentials);
             const xrayClient = new XrayClientCloud(xrayCredentials);
-            const jiraFieldRepository = new JiraFieldRepository(jiraClient, jiraOptions);
+            const jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
             const jiraFieldFetcher = new JiraIssueFetcherCloud(
                 jiraClient,
                 jiraFieldRepository,
@@ -345,11 +345,7 @@ export async function initClients(
                 kind: "cloud",
                 jiraClient: jiraClient,
                 xrayClient: xrayClient,
-                jiraRepository: new JiraRepository(
-                    jiraFieldRepository,
-                    jiraFieldFetcher,
-                    jiraOptions
-                ),
+                jiraRepository: new CachingJiraRepository(jiraFieldRepository, jiraFieldFetcher),
             };
         } else {
             throw new Error(
@@ -369,7 +365,7 @@ export async function initClients(
         logInfo("Jira PAT found. Setting up Xray server PAT credentials");
         await pingXrayServer(jiraOptions.url, credentials);
         const xrayClient = new XrayClientServer(jiraOptions.url, credentials);
-        const jiraFieldRepository = new JiraFieldRepository(jiraClient, jiraOptions);
+        const jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
         const jiraFieldFetcher = new JiraIssueFetcher(
             jiraClient,
             jiraFieldRepository,
@@ -379,7 +375,7 @@ export async function initClients(
             kind: "server",
             jiraClient: jiraClient,
             xrayClient: xrayClient,
-            jiraRepository: new JiraRepository(jiraFieldRepository, jiraFieldFetcher, jiraOptions),
+            jiraRepository: new CachingJiraRepository(jiraFieldRepository, jiraFieldFetcher),
         };
     } else if (ENV_JIRA_USERNAME in env && ENV_JIRA_PASSWORD in env && jiraOptions.url) {
         logInfo("Jira username and password found. Setting up Jira server basic auth credentials");
@@ -392,7 +388,7 @@ export async function initClients(
         logInfo("Jira username and password found. Setting up Xray server basic auth credentials");
         await pingXrayServer(jiraOptions.url, credentials);
         const xrayClient = new XrayClientServer(jiraOptions.url, credentials);
-        const jiraFieldRepository = new JiraFieldRepository(jiraClient, jiraOptions);
+        const jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
         const jiraFieldFetcher = new JiraIssueFetcher(
             jiraClient,
             jiraFieldRepository,
@@ -402,7 +398,7 @@ export async function initClients(
             kind: "server",
             jiraClient: jiraClient,
             xrayClient: xrayClient,
-            jiraRepository: new JiraRepository(jiraFieldRepository, jiraFieldFetcher, jiraOptions),
+            jiraRepository: new CachingJiraRepository(jiraFieldRepository, jiraFieldFetcher),
         };
     } else {
         throw new Error(

--- a/src/context.ts
+++ b/src/context.ts
@@ -80,9 +80,9 @@ export function clearPluginContext(): void {
 }
 
 /**
- * Returns an {@link InternalJiraOptions | `InternalJiraOptions`} instance based on parsed environment
- * variables and a provided options object. Environment variables will take precedence over the
- * options set in the object.
+ * Returns an {@link InternalJiraOptions | `InternalJiraOptions`} instance based on parsed
+ * environment variables and a provided options object. Environment variables will take precedence
+ * over the options set in the object.
  *
  * @param env - an object containing environment variables as properties
  * @param options - an options object containing Jira options

--- a/src/conversion/importExecution/importExecutionConverter.spec.ts
+++ b/src/conversion/importExecution/importExecutionConverter.spec.ts
@@ -42,7 +42,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json.tests).to.have.length(3);
     });
 
@@ -51,7 +51,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultUnknownStatus.json", "utf-8")
         );
         const { stubbedWarning } = stubLogging();
-        await expect(converter.convert(result)).to.eventually.be.rejectedWith(
+        await expect(converter.toXrayJson(result)).to.eventually.be.rejectedWith(
             "Failed to convert Cypress tests into Xray tests: No Cypress tests to upload"
         );
         expect(stubbedWarning.firstCall).to.have.been.calledWith(
@@ -74,7 +74,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json.info?.startDate).to.eq("2022-11-28T17:41:12Z");
         expect(json.info?.finishDate).to.eq("2022-11-28T17:41:19Z");
     });
@@ -83,7 +83,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expectToExist(json.tests);
         expect(json.tests[0].evidence).to.be.undefined;
         expect(json.tests[1].evidence).to.be.undefined;
@@ -97,7 +97,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.xray.uploadScreenshots = false;
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expectToExist(json.tests);
         expect(json.tests).to.have.length(3);
         expect(json.tests[0].evidence).to.be.undefined;
@@ -110,7 +110,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultProblematicScreenshot.json", "utf-8")
         );
         options.plugin.normalizeScreenshotNames = true;
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expectToExist(json.tests);
         expectToExist(json.tests[0].evidence);
         expect(json.tests[0].evidence[0].filename).to.eq("t_rtle_with_problem_tic_name.png");
@@ -120,7 +120,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultProblematicScreenshot.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expectToExist(json.tests);
         expectToExist(json.tests[0].evidence);
         expect(json.tests[0].evidence[0].filename).to.eq("tûrtle with problemätic name.png");
@@ -131,7 +131,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.xray.status = { passed: "it worked" };
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expectToExist(json.tests);
         expect(json.tests[0].status).to.eq("it worked");
         expect(json.tests[1].status).to.eq("it worked");
@@ -142,7 +142,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.xray.status = { failed: "it did not work" };
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expectToExist(json.tests);
         expect(json.tests[2].status).to.eq("it did not work");
     });
@@ -152,7 +152,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultPending.json", "utf-8")
         );
         options.xray.status = { pending: "still pending" };
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expectToExist(json.tests);
         expect(json.tests[0].status).to.eq("still pending");
         expect(json.tests[1].status).to.eq("still pending");
@@ -165,7 +165,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultSkipped.json", "utf-8")
         );
         options.xray.status = { skipped: "omit" };
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expectToExist(json.tests);
         expect(json.tests[1].status).to.eq("omit");
     });
@@ -174,7 +174,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json.tests).to.have.length(3);
         expectToExist(json.tests);
         expect(json.tests[0].testInfo).to.be.undefined;
@@ -186,7 +186,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json.tests).to.have.length(3);
         expectToExist(json.tests);
         expect(json.tests[0].testKey).to.eq("CYP-40");
@@ -199,7 +199,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.jira.testExecutionIssueKey = "CYP-123";
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json.testExecutionKey).to.eq("CYP-123");
     });
 
@@ -208,7 +208,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.jira.testPlanIssueKey = "CYP-123";
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json?.info?.testPlanKey).to.eq("CYP-123");
     });
 
@@ -216,7 +216,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json.testExecutionKey).to.be.undefined;
     });
 
@@ -224,7 +224,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json?.info?.testPlanKey).to.be.undefined;
     });
 
@@ -233,7 +233,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.jira.testExecutionIssueSummary = "Jeffrey's Test";
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json?.info?.summary).to.eq("Jeffrey's Test");
     });
 
@@ -241,7 +241,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json?.info?.summary).to.eq("Execution Results [1669657272234]");
     });
 
@@ -250,7 +250,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.jira.testExecutionIssueKey = "CYP-100";
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json?.info?.summary).to.be.undefined;
     });
 
@@ -259,7 +259,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.jira.testExecutionIssueDescription = "Very Useful Text";
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json?.info?.description).to.eq("Very Useful Text");
     });
 
@@ -267,7 +267,7 @@ describe("the import execution converter", () => {
         const result: CypressCommandLine.CypressRunResult = JSON.parse(
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json?.info?.description).to.eq(
             dedent(`
                 Cypress version: 11.1.0
@@ -281,7 +281,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.jira.testExecutionIssueKey = "CYP-100";
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json?.info?.description).to.be.undefined;
     });
 
@@ -290,7 +290,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         converter = new ImportExecutionConverter(options, true);
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expectToExist(json.tests);
         expect(json.tests).to.have.length(3);
         expect(json.tests[0].status).to.eq("PASSED");
@@ -303,7 +303,7 @@ describe("the import execution converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         options.xray.testEnvironments = ["DEV"];
-        const json = await converter.convert(result);
+        const json = await converter.toXrayJson(result);
         expect(json?.info?.testEnvironments).to.deep.eq(["DEV"]);
     });
 });

--- a/src/conversion/importExecution/importExecutionConverter.ts
+++ b/src/conversion/importExecution/importExecutionConverter.ts
@@ -1,19 +1,17 @@
 import { CypressRunResult as CypressRunResult_V_12 } from "../../types/cypress/12.0.0/api";
 import { CypressRunResult as CypressRunResult_V_13 } from "../../types/cypress/13.0.0/api";
 import { InternalOptions } from "../../types/plugin";
-import { StringMap } from "../../types/util";
 import { IXrayTestExecutionResults } from "../../types/xray/importTestExecutionResults";
 import { dedent } from "../../util/dedent";
 import { truncateISOTime } from "../../util/time";
 import { TestConverter } from "./testConverter";
 
-export type TestIssueData = {
-    summaries: StringMap<string>;
-    testTypes: StringMap<string>;
-};
-
 type CypressRunResultType = CypressRunResult_V_12 | CypressRunResult_V_13;
 
+/**
+ * A class for converting Cypress run results into Xray JSON. Both Xray server JSON and Xray cloud
+ * JSON are supported.
+ */
 export class ImportExecutionConverter {
     /**
      * The configured plugin options.
@@ -33,7 +31,7 @@ export class ImportExecutionConverter {
         this.options = options;
     }
 
-    public async convert(results: CypressRunResultType): Promise<IXrayTestExecutionResults> {
+    public async toXrayJson(results: CypressRunResultType): Promise<IXrayTestExecutionResults> {
         const testConverter: TestConverter = new TestConverter(this.options, this.isCloudConverter);
         return {
             testExecutionKey: this.options.jira.testExecutionIssueKey,
@@ -46,7 +44,7 @@ export class ImportExecutionConverter {
                 testPlanKey: this.options.jira.testPlanIssueKey,
                 testEnvironments: this.options.xray.testEnvironments,
             },
-            tests: await testConverter.convert(results),
+            tests: await testConverter.toXrayTests(results),
         };
     }
 

--- a/src/conversion/importExecution/testConverter.spec.ts
+++ b/src/conversion/importExecution/testConverter.spec.ts
@@ -45,7 +45,7 @@ describe("the test converter", () => {
         );
         const converter = new TestConverter(options, false);
         const { stubbedWarning } = stubLogging();
-        const json = await converter.convert(result);
+        const json = await converter.toXrayTests(result);
         expect(stubbedWarning).to.have.been.calledOnceWithExactly(
             dedent(`
                 Screenshot will not be uploaded: ./test/resources/small.png
@@ -79,7 +79,7 @@ describe("the test converter", () => {
             { featureFileExtension: ".feature" }
         );
         const converter = new TestConverter(options, true);
-        await expect(converter.convert(result)).to.eventually.be.rejectedWith(
+        await expect(converter.toXrayTests(result)).to.eventually.be.rejectedWith(
             "Failed to extract test run data: Only Cucumber tests were executed"
         );
     });
@@ -100,7 +100,7 @@ describe("the test converter", () => {
             { featureFileExtension: ".ts" }
         );
         const converter = new TestConverter(options, false);
-        await expect(converter.convert(result)).to.eventually.be.rejectedWith(
+        await expect(converter.toXrayTests(result)).to.eventually.be.rejectedWith(
             "Failed to extract test run data: Only Cucumber tests were executed"
         );
     });
@@ -110,7 +110,7 @@ describe("the test converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         const converter = new TestConverter(options, false);
-        const json = await converter.convert(result);
+        const json = await converter.toXrayTests(result);
         expect(json).to.deep.eq([
             {
                 testKey: "CYP-40",
@@ -144,7 +144,7 @@ describe("the test converter", () => {
             readFileSync("./test/resources/runResult_13_0_0.json", "utf-8")
         );
         const converter = new TestConverter(options, false);
-        const json = await converter.convert(result);
+        const json = await converter.toXrayTests(result);
         expect(json).to.deep.eq([
             {
                 testKey: "CYP-452",
@@ -190,7 +190,7 @@ describe("the test converter", () => {
             readFileSync("./test/resources/runResultExistingTestIssues.json", "utf-8")
         );
         const converter = new TestConverter(options, true);
-        const json = await converter.convert(result);
+        const json = await converter.toXrayTests(result);
         expect(json).to.deep.eq([
             {
                 testKey: "CYP-40",
@@ -224,7 +224,7 @@ describe("the test converter", () => {
             readFileSync("./test/resources/runResult_13_0_0.json", "utf-8")
         );
         const converter = new TestConverter(options, true);
-        const json = await converter.convert(result);
+        const json = await converter.toXrayTests(result);
         expect(json).to.deep.eq([
             {
                 testKey: "CYP-452",

--- a/src/conversion/importExecution/testConverter.ts
+++ b/src/conversion/importExecution/testConverter.ts
@@ -21,6 +21,12 @@ import { truncateISOTime } from "../../util/time";
 import { ITestRunData, getTestRunData_V12, getTestRunData_V13 } from "./runConversion";
 import { getXrayStatus } from "./statusConversion";
 
+/**
+ * A class for converting Cypress run results into Xray test JSON.
+ *
+ * @see https://docs.getxray.app/display/XRAY/Import+Execution+Results#ImportExecutionResults-%22tests%22object-TestRundetails
+ * @see https://docs.getxray.app/display/XRAYCLOUD/Using+Xray+JSON+format+to+import+execution+results#UsingXrayJSONformattoimportexecutionresults-%22test%22object-TestRundetails
+ */
 export class TestConverter {
     /**
      * Construct a new converter with access to the provided options. The cloud converter flag is
@@ -35,7 +41,7 @@ export class TestConverter {
         private readonly isCloudConverter: boolean
     ) {}
 
-    public async convert(
+    public async toXrayTests(
         runResults: CypressRunResult_V12 | CypressRunResult_V13
     ): Promise<[IXrayTest, ...IXrayTest[]]> {
         const testRunData = await this.getTestRunData(runResults);

--- a/src/conversion/importExecutionCucumberMultipart/importExecutionCucumberMultipartConverter.spec.ts
+++ b/src/conversion/importExecutionCucumberMultipart/importExecutionCucumberMultipartConverter.spec.ts
@@ -1,0 +1,255 @@
+import { expect } from "chai";
+import { readFileSync } from "fs";
+import { SupportedFields } from "../../repository/jira/fields/jiraIssueFetcher";
+import { IJiraRepository } from "../../repository/jira/jiraRepository";
+import { CucumberMultipartFeature } from "../../types/xray/requests/importExecutionCucumberMultipart";
+import { ImportExecutionCucumberMultipartConverter } from "./importExecutionCucumberMultipartConverter";
+
+describe("the import execution cucumber multpart converter", () => {
+    let mockedJiraRepository: IJiraRepository;
+
+    beforeEach(() => {
+        mockedJiraRepository = {
+            getFieldId: () => {
+                throw new Error("Mock called unexpectedly");
+            },
+            getSummaries: () => {
+                throw new Error("Mock called unexpectedly");
+            },
+            getDescriptions: () => {
+                throw new Error("Mock called unexpectedly");
+            },
+            getTestTypes: () => {
+                throw new Error("Mock called unexpectedly");
+            },
+            getLabels: () => {
+                throw new Error("Mock called unexpectedly");
+            },
+        };
+    });
+
+    describe("server", () => {
+        it("converts cucumber JSON into Xray JSON", async () => {
+            const cucumberReport: CucumberMultipartFeature[] = JSON.parse(
+                readFileSync(
+                    "./test/resources/fixtures/xray/requests/importExecutionCucumberMultipartServer.json",
+                    "utf-8"
+                )
+            );
+            const converter = new ImportExecutionCucumberMultipartConverter(
+                {
+                    jira: {
+                        projectKey: "CYP",
+                        testExecutionIssueDetails: { subtask: false, id: "issue_1578" },
+                    },
+                    xray: { uploadScreenshots: false },
+                },
+                false,
+                mockedJiraRepository
+            );
+            const multipartJson = await converter.convert([cucumberReport[0]], {
+                browserName: "Firefox",
+                browserVersion: "123.11.6",
+                cypressVersion: "42.4.9",
+                startedTestsAt: "2023-09-09T10:59:28.829Z",
+            });
+            expect(multipartJson.features).to.be.an("array").with.length(1);
+            expect(multipartJson.info).to.deep.eq({
+                fields: {
+                    project: {
+                        key: "CYP",
+                    },
+                    summary: "Execution Results [1694257168829]",
+                    description: "Cypress version: 42.4.9\nBrowser: Firefox (123.11.6)",
+                    issuetype: { subtask: false, id: "issue_1578" },
+                },
+            });
+        });
+
+        it("includes configured test plan issue keys", async () => {
+            const cucumberReport: CucumberMultipartFeature[] = JSON.parse(
+                readFileSync(
+                    "./test/resources/fixtures/xray/requests/importExecutionCucumberMultipartServer.json",
+                    "utf-8"
+                )
+            );
+            mockedJiraRepository.getFieldId = async (fieldName: SupportedFields) => {
+                if (fieldName === SupportedFields.TEST_PLAN) {
+                    return "customfield_12345";
+                }
+                throw new Error(`Unexpected argument: ${fieldName}`);
+            };
+            const converter = new ImportExecutionCucumberMultipartConverter(
+                {
+                    jira: {
+                        projectKey: "CYP",
+                        testPlanIssueKey: "CYP-123",
+                        testExecutionIssueDetails: { subtask: false },
+                    },
+                    xray: { uploadScreenshots: false },
+                },
+                false,
+                mockedJiraRepository
+            );
+            const multipartJson = await converter.convert([cucumberReport[0]], {
+                browserName: "Firefox",
+                browserVersion: "123.11.6",
+                cypressVersion: "42.4.9",
+                startedTestsAt: "2023-09-09T10:59:28.829Z",
+            });
+            expect(multipartJson.info.fields).to.have.property("customfield_12345", "CYP-123");
+        });
+
+        it("includes configured test environments", async () => {
+            const cucumberReport: CucumberMultipartFeature[] = JSON.parse(
+                readFileSync(
+                    "./test/resources/fixtures/xray/requests/importExecutionCucumberMultipartServer.json",
+                    "utf-8"
+                )
+            );
+            mockedJiraRepository.getFieldId = async (fieldName: SupportedFields) => {
+                if (fieldName === SupportedFields.TEST_ENVIRONMENTS) {
+                    return "customfield_45678";
+                }
+                throw new Error(`Unexpected argument: ${fieldName}`);
+            };
+            const converter = new ImportExecutionCucumberMultipartConverter(
+                {
+                    jira: {
+                        projectKey: "CYP",
+                        testExecutionIssueDetails: { subtask: false },
+                    },
+                    xray: { testEnvironments: ["DEV", "PROD"], uploadScreenshots: false },
+                },
+                false,
+                mockedJiraRepository
+            );
+            const multipartJson = await converter.convert([cucumberReport[0]], {
+                browserName: "Firefox",
+                browserVersion: "123.11.6",
+                cypressVersion: "42.4.9",
+                startedTestsAt: "2023-09-09T10:59:28.829Z",
+            });
+            expect(multipartJson.info.fields).to.have.deep.property("customfield_45678", [
+                "DEV",
+                "PROD",
+            ]);
+        });
+    });
+
+    describe("cloud", () => {
+        it("converts cucumber JSON into Xray JSON", async () => {
+            const cucumberReport: CucumberMultipartFeature[] = JSON.parse(
+                readFileSync(
+                    "./test/resources/fixtures/xray/requests/importExecutionCucumberMultipartCloud.json",
+                    "utf-8"
+                )
+            );
+            const converter = new ImportExecutionCucumberMultipartConverter(
+                {
+                    jira: {
+                        projectKey: "CYP",
+                        testExecutionIssueDetails: { subtask: false, id: "issue_1578" },
+                    },
+                    xray: { uploadScreenshots: false },
+                },
+                true,
+                mockedJiraRepository
+            );
+            const multipartJson = await converter.convert([cucumberReport[0]], {
+                browserName: "Firefox",
+                browserVersion: "123.11.6",
+                cypressVersion: "42.4.9",
+                startedTestsAt: "2023-09-09T10:59:28.829Z",
+            });
+            expect(multipartJson.features).to.be.an("array").with.length(1);
+            expect(multipartJson.info).to.deep.eq({
+                fields: {
+                    project: {
+                        key: "CYP",
+                    },
+                    summary: "Execution Results [1694257168829]",
+                    description: "Cypress version: 42.4.9\nBrowser: Firefox (123.11.6)",
+                    issuetype: { subtask: false, id: "issue_1578" },
+                },
+                xrayFields: {
+                    testPlanKey: undefined,
+                    environments: undefined,
+                },
+            });
+        });
+
+        it("includes configured test plan issue keys", async () => {
+            const cucumberReport: CucumberMultipartFeature[] = JSON.parse(
+                readFileSync(
+                    "./test/resources/fixtures/xray/requests/importExecutionCucumberMultipartCloud.json",
+                    "utf-8"
+                )
+            );
+            mockedJiraRepository.getFieldId = async (fieldName: SupportedFields) => {
+                if (fieldName === SupportedFields.TEST_PLAN) {
+                    return "customfield_12345";
+                }
+                throw new Error(`Unexpected argument: ${fieldName}`);
+            };
+            const converter = new ImportExecutionCucumberMultipartConverter(
+                {
+                    jira: {
+                        projectKey: "CYP",
+                        testPlanIssueKey: "CYP-123",
+                        testExecutionIssueDetails: { subtask: false },
+                    },
+                    xray: { uploadScreenshots: false },
+                },
+                true,
+                mockedJiraRepository
+            );
+            const multipartJson = await converter.convert([cucumberReport[0]], {
+                browserName: "Firefox",
+                browserVersion: "123.11.6",
+                cypressVersion: "42.4.9",
+                startedTestsAt: "2023-09-09T10:59:28.829Z",
+            });
+            expect(multipartJson.info).to.have.deep.property("xrayFields", {
+                testPlanKey: "CYP-123",
+                environments: undefined,
+            });
+        });
+
+        it("includes configured test environments", async () => {
+            const cucumberReport: CucumberMultipartFeature[] = JSON.parse(
+                readFileSync(
+                    "./test/resources/fixtures/xray/requests/importExecutionCucumberMultipartCloud.json",
+                    "utf-8"
+                )
+            );
+            mockedJiraRepository.getFieldId = async (fieldName: SupportedFields) => {
+                if (fieldName === SupportedFields.TEST_ENVIRONMENTS) {
+                    return "customfield_45678";
+                }
+                throw new Error(`Unexpected argument: ${fieldName}`);
+            };
+            const converter = new ImportExecutionCucumberMultipartConverter(
+                {
+                    jira: {
+                        projectKey: "CYP",
+                        testExecutionIssueDetails: { subtask: false },
+                    },
+                    xray: { testEnvironments: ["DEV", "PROD"], uploadScreenshots: false },
+                },
+                true,
+                mockedJiraRepository
+            );
+            const multipartJson = await converter.convert([cucumberReport[0]], {
+                browserName: "Firefox",
+                browserVersion: "123.11.6",
+                cypressVersion: "42.4.9",
+                startedTestsAt: "2023-09-09T10:59:28.829Z",
+            });
+            expect(multipartJson.info).to.have.deep.property("xrayFields", {
+                testPlanKey: undefined,
+                environments: ["DEV", "PROD"],
+            });
+        });
+    });
+});

--- a/src/conversion/importExecutionCucumberMultipart/multipartFeatureBuilder.spec.ts
+++ b/src/conversion/importExecutionCucumberMultipart/multipartFeatureBuilder.spec.ts
@@ -3,9 +3,9 @@ import { readFileSync } from "fs";
 import { expectToExist, stubLogging } from "../../../test/util";
 import { CucumberMultipartFeature } from "../../types/xray/requests/importExecutionCucumberMultipart";
 import { dedent } from "../../util/dedent";
-import { getMultipartFeatures } from "./multipartFeatureConversion";
+import { buildMultipartFeatures } from "./multipartFeatureBuilder";
 
-describe("getMultipartFeatures", () => {
+describe("buildMultipartFeatures", () => {
     it("includes all tagged features and tests", async () => {
         const cucumberReport: CucumberMultipartFeature[] = JSON.parse(
             readFileSync(
@@ -13,7 +13,7 @@ describe("getMultipartFeatures", () => {
                 "utf-8"
             )
         );
-        const features = getMultipartFeatures(cucumberReport, {
+        const features = buildMultipartFeatures(cucumberReport, {
             projectKey: "CYP",
             useCloudTags: true,
         });
@@ -29,7 +29,7 @@ describe("getMultipartFeatures", () => {
                 "utf-8"
             )
         );
-        const features = getMultipartFeatures(cucumberReport, {
+        const features = buildMultipartFeatures(cucumberReport, {
             testExecutionIssueKey: "CYP-456",
             projectKey: "CYP",
             useCloudTags: true,
@@ -45,7 +45,7 @@ describe("getMultipartFeatures", () => {
                 "utf-8"
             )
         );
-        const features = getMultipartFeatures(cucumberReport, {
+        const features = buildMultipartFeatures(cucumberReport, {
             includeScreenshots: true,
             projectKey: "CYP",
             useCloudTags: true,
@@ -63,7 +63,7 @@ describe("getMultipartFeatures", () => {
                 "utf-8"
             )
         );
-        const features = getMultipartFeatures(cucumberReport, {
+        const features = buildMultipartFeatures(cucumberReport, {
             includeScreenshots: false,
             projectKey: "CYP",
             useCloudTags: true,
@@ -84,7 +84,7 @@ describe("getMultipartFeatures", () => {
                 "utf-8"
             )
         );
-        const features = getMultipartFeatures(cucumberReport, {
+        const features = buildMultipartFeatures(cucumberReport, {
             includeScreenshots: false,
             projectKey: "CYP",
             useCloudTags: false,
@@ -116,7 +116,7 @@ describe("getMultipartFeatures", () => {
                 "utf-8"
             )
         );
-        const features = getMultipartFeatures(cucumberReport, {
+        const features = buildMultipartFeatures(cucumberReport, {
             includeScreenshots: false,
             projectKey: "CYP",
             useCloudTags: true,

--- a/src/conversion/importExecutionCucumberMultipart/multipartFeatureBuilder.ts
+++ b/src/conversion/importExecutionCucumberMultipart/multipartFeatureBuilder.ts
@@ -13,7 +13,16 @@ import {
     multipleTestKeysInCucumberScenarioError,
 } from "../../util/errors";
 
-export function getMultipartFeatures(
+/**
+ * Modifies the input Cucumber JSON results by adding test execution issue tags and filtering
+ * screenshots, based on the options provided. The function also asserts that every test contained
+ * within the results has been appropriately tagged with either Xray cloud or Xray server tags.
+ *
+ * @param input - the Cucumber JSON results
+ * @param options - the options for results modification
+ * @returns the modified Cucumber JSON results
+ */
+export function buildMultipartFeatures(
     input: CucumberMultipartFeature[],
     options: {
         testExecutionIssueKey?: string;
@@ -21,7 +30,7 @@ export function getMultipartFeatures(
         projectKey: string;
         useCloudTags: boolean;
     }
-) {
+): CucumberMultipartFeature[] {
     const tests: CucumberMultipartFeature[] = [];
     input.forEach((result: CucumberMultipartFeature) => {
         const test: CucumberMultipartFeature = {

--- a/src/conversion/importExecutionCucumberMultipart/multipartInfoBuilder.spec.ts
+++ b/src/conversion/importExecutionCucumberMultipart/multipartInfoBuilder.spec.ts
@@ -1,10 +1,10 @@
 import { expect } from "chai";
 import { dedent } from "../../util/dedent";
-import { getMultipartInfoCloud, getMultipartInfoServer } from "./multipartInfoConversion";
+import { buildMultipartInfoCloud, buildMultipartInfoServer } from "./multipartInfoBuilder";
 
-describe("getMultipartInfoCloud", () => {
+describe("buildMultipartInfoCloud", () => {
     it("adds default information", async () => {
-        const info = getMultipartInfoCloud(
+        const info = buildMultipartInfoCloud(
             {
                 startedTestsAt: "2023-09-28T15:51:36.000Z",
                 browserName: "Chromium",
@@ -42,7 +42,7 @@ describe("getMultipartInfoCloud", () => {
     });
 
     it("uses provided summaries", async () => {
-        const info = getMultipartInfoCloud(
+        const info = buildMultipartInfoCloud(
             {
                 startedTestsAt: "2023-09-28 17:51:36",
                 browserName: "Chromium",
@@ -61,7 +61,7 @@ describe("getMultipartInfoCloud", () => {
     });
 
     it("uses provided descriptions", async () => {
-        const info = getMultipartInfoCloud(
+        const info = buildMultipartInfoCloud(
             {
                 startedTestsAt: "2023-09-28 17:51:36",
                 browserName: "Chromium",
@@ -80,7 +80,7 @@ describe("getMultipartInfoCloud", () => {
     });
 
     it("uses provided test plans", async () => {
-        const info = getMultipartInfoCloud(
+        const info = buildMultipartInfoCloud(
             {
                 startedTestsAt: "2023-09-28 17:51:36",
                 browserName: "Chromium",
@@ -101,9 +101,9 @@ describe("getMultipartInfoCloud", () => {
     });
 });
 
-describe("getMultipartInfoServer", () => {
+describe("buildMultipartInfoServer", () => {
     it("adds default information", async () => {
-        const info = getMultipartInfoServer(
+        const info = buildMultipartInfoServer(
             {
                 startedTestsAt: "2023-09-28T15:51:36.000Z",
                 browserName: "Chromium",
@@ -135,7 +135,7 @@ describe("getMultipartInfoServer", () => {
     });
 
     it("uses provided summaries", async () => {
-        const info = getMultipartInfoServer(
+        const info = buildMultipartInfoServer(
             {
                 startedTestsAt: "2023-09-28 17:51:36",
                 browserName: "Chromium",
@@ -154,7 +154,7 @@ describe("getMultipartInfoServer", () => {
     });
 
     it("uses provided descriptions", async () => {
-        const info = getMultipartInfoServer(
+        const info = buildMultipartInfoServer(
             {
                 startedTestsAt: "2023-09-28 17:51:36",
                 browserName: "Chromium",
@@ -173,7 +173,7 @@ describe("getMultipartInfoServer", () => {
     });
 
     it("uses provided test plans", async () => {
-        const info = getMultipartInfoServer(
+        const info = buildMultipartInfoServer(
             {
                 startedTestsAt: "2023-09-28 17:51:36",
                 browserName: "Chromium",
@@ -195,7 +195,7 @@ describe("getMultipartInfoServer", () => {
     });
 
     it("uses provided test environments", async () => {
-        const info = getMultipartInfoServer(
+        const info = buildMultipartInfoServer(
             {
                 startedTestsAt: "2023-09-28 17:51:36",
                 browserName: "Chromium",

--- a/src/conversion/importExecutionCucumberMultipart/multipartInfoBuilder.ts
+++ b/src/conversion/importExecutionCucumberMultipart/multipartInfoBuilder.ts
@@ -8,10 +8,11 @@ import { dedent } from "../../util/dedent";
 /**
  * Interface containing general/minimal Cypress run data.
  */
-export type RunData = Pick<
-    CypressCommandLine.CypressRunResult,
-    "browserName" | "browserVersion" | "cypressVersion" | "startedTestsAt"
->;
+export interface IRunData
+    extends Pick<
+        CypressCommandLine.CypressRunResult,
+        "browserName" | "browserVersion" | "cypressVersion" | "startedTestsAt"
+    > {}
 
 /**
  * Additional information used by test execution issues when uploading Cucumber results.
@@ -52,8 +53,8 @@ export interface TestExecutionIssueDataServer extends TestExecutionIssueData {
  * @param testExecutionIssueData - additional information to consider
  * @returns the Cucumber multipart information data for Xray server
  */
-export function getMultipartInfoServer(
-    runData: RunData,
+export function buildMultipartInfoServer(
+    runData: IRunData,
     testExecutionIssueData: TestExecutionIssueDataServer
 ): ICucumberMultipartInfo {
     const multipartInfo: ICucumberMultipartInfo = {
@@ -93,8 +94,8 @@ export function getMultipartInfoServer(
  * @param testExecutionIssueData - additional information to consider
  * @returns the Cucumber multipart information data for Xray cloud
  */
-export function getMultipartInfoCloud(
-    runData: RunData,
+export function buildMultipartInfoCloud(
+    runData: IRunData,
     testExecutionIssueData: TestExecutionIssueData
 ): CucumberMultipartInfoCloud {
     return {

--- a/src/hooks.spec.ts
+++ b/src/hooks.spec.ts
@@ -15,9 +15,9 @@ import {
     initXrayOptions,
 } from "./context";
 import { beforeRunHook, synchronizeFile } from "./hooks";
-import { JiraFieldRepository } from "./repository/jira/fields/jiraFieldRepository";
+import { CachingJiraFieldRepository } from "./repository/jira/fields/jiraFieldRepository";
 import { JiraIssueFetcher } from "./repository/jira/fields/jiraIssueFetcher";
-import { JiraRepository } from "./repository/jira/jiraRepository";
+import { CachingJiraRepository } from "./repository/jira/jiraRepository";
 import { ClientCombination, InternalOptions } from "./types/plugin";
 import { dedent } from "./util/dedent";
 
@@ -48,7 +48,7 @@ describe("the hooks", () => {
         };
         const jiraClient = new JiraClientServer("https://example.org", new PATCredentials("token"));
         const xrayClient = new XrayClientServer("https://example.org", new PATCredentials("token"));
-        const jiraFieldRepository = new JiraFieldRepository(jiraClient, options.jira);
+        const jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
         const jiraFieldFetcher = new JiraIssueFetcher(
             jiraClient,
             jiraFieldRepository,
@@ -58,7 +58,7 @@ describe("the hooks", () => {
             kind: "server",
             jiraClient: jiraClient,
             xrayClient: xrayClient,
-            jiraRepository: new JiraRepository(jiraFieldRepository, jiraFieldFetcher, options.jira),
+            jiraRepository: new CachingJiraRepository(jiraFieldRepository, jiraFieldFetcher),
         };
     });
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -12,7 +12,7 @@ import {
     getCucumberIssueData,
 } from "./preprocessing/preprocessing";
 import { SupportedFields } from "./repository/jira/fields/jiraIssueFetcher";
-import { IJiraRepository, JiraRepository } from "./repository/jira/jiraRepository";
+import { CachingJiraRepository, IJiraRepository } from "./repository/jira/jiraRepository";
 import { IIssueTypeDetails } from "./types/jira/responses/issueTypeDetails";
 import { ClientCombination, InternalOptions } from "./types/plugin";
 import { StringMap, nonNull } from "./types/util";
@@ -353,7 +353,7 @@ async function resetLabels(
     issueData: FeatureFileIssueDataTest[],
     testLabels: StringMap<string[]>,
     jiraClient: IJiraClient,
-    jiraRepository: JiraRepository
+    jiraRepository: CachingJiraRepository
 ) {
     for (let i = 0; i < issueData.length; i++) {
         const issueKey = issueData[i].key;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -12,7 +12,7 @@ import {
     getCucumberIssueData,
 } from "./preprocessing/preprocessing";
 import { SupportedFields } from "./repository/jira/fields/jiraIssueFetcher";
-import { CachingJiraRepository, IJiraRepository } from "./repository/jira/jiraRepository";
+import { IJiraRepository } from "./repository/jira/jiraRepository";
 import { IIssueTypeDetails } from "./types/jira/responses/issueTypeDetails";
 import { ClientCombination, InternalOptions } from "./types/plugin";
 import { StringMap, nonNull } from "./types/util";
@@ -353,7 +353,7 @@ async function resetLabels(
     issueData: FeatureFileIssueDataTest[],
     testLabels: StringMap<string[]>,
     jiraClient: IJiraClient,
-    jiraRepository: CachingJiraRepository
+    jiraRepository: IJiraRepository
 ) {
     for (let i = 0; i < issueData.length; i++) {
         const issueKey = issueData[i].key;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -176,7 +176,7 @@ async function uploadCypressResults(
 ) {
     const converter = new ImportExecutionConverter(options, clients.kind === "cloud");
     try {
-        const cypressExecution = await converter.convert(runResult);
+        const cypressExecution = await converter.toXrayJson(runResult);
         return await clients.xrayClient.importExecution(cypressExecution);
     } catch (error: unknown) {
         logError(errorMessage(error));
@@ -318,10 +318,7 @@ async function resetSummaries(
             continue;
         }
         if (oldSummary !== newSummary) {
-            const summaryFieldId = await jiraRepository.getFieldId(
-                SupportedFields.SUMMARY,
-                "summary"
-            );
+            const summaryFieldId = await jiraRepository.getFieldId(SupportedFields.SUMMARY);
             const fields: StringMap<string> = {};
             fields[summaryFieldId] = oldSummary;
             logDebug(

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -8,9 +8,9 @@ import { XrayClientServer } from "./client/xray/xrayClientServer";
 import * as context from "./context";
 import * as hooks from "./hooks";
 import { addXrayResultUpload, configureXrayPlugin, syncFeatureFile } from "./plugin";
-import { JiraFieldRepository } from "./repository/jira/fields/jiraFieldRepository";
+import { CachingJiraFieldRepository } from "./repository/jira/fields/jiraFieldRepository";
 import { JiraIssueFetcher } from "./repository/jira/fields/jiraIssueFetcher";
-import { JiraRepository } from "./repository/jira/jiraRepository";
+import { CachingJiraRepository } from "./repository/jira/jiraRepository";
 import { Options, PluginContext } from "./types/plugin";
 import { dedent } from "./util/dedent";
 
@@ -29,17 +29,13 @@ describe("the plugin", () => {
                 url: "https://example.org",
             }
         );
-        const jiraFieldRepository = new JiraFieldRepository(jiraClient, jiraOptions);
+        const jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
         const jiraFieldFetcher = new JiraIssueFetcher(
             jiraClient,
             jiraFieldRepository,
             jiraOptions.fields
         );
-        const jiraRepository = new JiraRepository(
-            jiraFieldRepository,
-            jiraFieldFetcher,
-            jiraOptions
-        );
+        const jiraRepository = new CachingJiraRepository(jiraFieldRepository, jiraFieldFetcher);
         pluginContext = {
             cypress: config,
             internal: {

--- a/src/repository/jira/fields/jiraFieldRepository.spec.ts
+++ b/src/repository/jira/fields/jiraFieldRepository.spec.ts
@@ -3,32 +3,22 @@ import chaiAsPromised from "chai-as-promised";
 import { stub } from "sinon";
 import { BasicAuthCredentials } from "../../../authentication/credentials";
 import { JiraClientServer } from "../../../client/jira/jiraClientServer";
-import { initJiraOptions } from "../../../context";
-import { InternalJiraOptions } from "../../../types/plugin";
 import { dedent } from "../../../util/dedent";
-import { JiraFieldRepository } from "./jiraFieldRepository";
+import { CachingJiraFieldRepository } from "./jiraFieldRepository";
 import { SupportedFields } from "./jiraIssueFetcher";
 
 chai.use(chaiAsPromised);
 
 describe("the jira field repository", () => {
-    let jiraOptions: InternalJiraOptions;
     let jiraClient: JiraClientServer;
-    let repository: JiraFieldRepository;
+    let repository: CachingJiraFieldRepository;
 
     beforeEach(() => {
-        jiraOptions = initJiraOptions(
-            {},
-            {
-                projectKey: "CYP",
-                url: "https://example.org",
-            }
-        );
         jiraClient = new JiraClientServer(
             "https://example.org",
             new BasicAuthCredentials("user", "xyz")
         );
-        repository = new JiraFieldRepository(jiraClient, jiraOptions);
+        repository = new CachingJiraFieldRepository(jiraClient);
     });
 
     it("fetches fields case-insensitively", async () => {

--- a/src/repository/jira/fields/jiraIssueFetcher.ts
+++ b/src/repository/jira/fields/jiraIssueFetcher.ts
@@ -21,14 +21,56 @@ export enum SupportedFields {
     TEST_TYPE = "test type",
 }
 
+/**
+ * An interface describing classes which can fetch Jira issue data such as descriptions, labels or
+ * summaries.
+ */
 export interface IJiraIssueFetcher {
+    /**
+     * Fetches the descriptions of issues specified by their Jira issue keys.
+     *
+     * @param issueKeys - the issue keys
+     * @returns a mapping of issue keys to descriptions
+     */
     fetchDescriptions(...issueKeys: string[]): Promise<StringMap<string>>;
+    /**
+     * Fetches the labels of issues specified by their Jira issue keys.
+     *
+     * @param issueKeys - the issue keys
+     * @returns a mapping of issue keys to their labels
+     */
     fetchLabels(...issueKeys: string[]): Promise<StringMap<string[]>>;
+    /**
+     * Fetches the summaries of issues specified by their Jira issue keys.
+     *
+     * @param issueKeys - the issue keys
+     * @returns a mapping of issue keys to summaries
+     */
     fetchSummaries(...issueKeys: string[]): Promise<StringMap<string>>;
+    /**
+     * Fetches the test types of Xray test issues specified by their Jira issue keys.
+     *
+     * @param issueKeys - the issue keys
+     * @returns a mapping of issue keys to their descriptions
+     */
     fetchTestTypes(...issueKeys: string[]): Promise<StringMap<string>>;
 }
 
+/**
+ * A generic Jira issue data fetcher which fetches issue data for every call, i.e. does not perform
+ * any caching.
+ */
 export class JiraIssueFetcher implements IJiraIssueFetcher {
+    /**
+     * Constructs a new Jira issue fetcher. The Jira client is necessary for accessing Jira. The
+     * field repository is required because issue data can only be retrieved through Jira fields,
+     * which might have custom field IDs. An optional mapping of known field IDs can be provided,
+     * which will then be used instead of accessing the field repository.
+     *
+     * @param jiraClient - the Jira client
+     * @param jiraFieldRepository - the Jira field repository
+     * @param fieldIds - an optional mapping of known field IDs
+     */
     constructor(
         private readonly jiraClient: IJiraClient,
         private readonly jiraFieldRepository: IJiraFieldRepository,

--- a/src/repository/jira/jiraRepository.spec.ts
+++ b/src/repository/jira/jiraRepository.spec.ts
@@ -6,9 +6,9 @@ import { initJiraOptions } from "../../context";
 import { InternalJiraOptions } from "../../types/plugin";
 import { StringMap } from "../../types/util";
 import { dedent } from "../../util/dedent";
-import { IJiraFieldRepository, JiraFieldRepository } from "./fields/jiraFieldRepository";
+import { CachingJiraFieldRepository, IJiraFieldRepository } from "./fields/jiraFieldRepository";
 import { IJiraIssueFetcher, JiraIssueFetcher } from "./fields/jiraIssueFetcher";
-import { IJiraRepository, JiraRepository } from "./jiraRepository";
+import { CachingJiraRepository, IJiraRepository } from "./jiraRepository";
 
 describe("the cloud issue repository", () => {
     let jiraOptions: InternalJiraOptions;
@@ -28,13 +28,13 @@ describe("the cloud issue repository", () => {
             "https://example.org",
             new BasicAuthCredentials("user", "xyz")
         );
-        jiraFieldRepository = new JiraFieldRepository(jiraClient, jiraOptions);
+        jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
         jiraFieldFetcher = new JiraIssueFetcher(
             jiraClient,
             jiraFieldRepository,
             jiraOptions.fields
         );
-        repository = new JiraRepository(jiraFieldRepository, jiraFieldFetcher, jiraOptions);
+        repository = new CachingJiraRepository(jiraFieldRepository, jiraFieldFetcher);
     });
 
     describe("getSummaries", () => {
@@ -62,7 +62,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const summaries = await repository.getSummaries("CYP-123", "CYP-456", "CYP-789");
             expect(summaries).to.deep.eq({
                 "CYP-123": "Hello",
@@ -98,7 +98,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             await repository.getSummaries("CYP-123", "CYP-789");
             const summaries = await repository.getSummaries("CYP-123", "CYP-456", "CYP-789");
             expect(summaries).to.deep.eq({
@@ -132,7 +132,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const { stubbedError } = stubLogging();
             const summaries = await repository.getSummaries("CYP-123", "CYP-456", "CYP-789");
             expect(stubbedError).to.have.been.calledOnceWithExactly(
@@ -164,7 +164,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const { stubbedError } = stubLogging();
             const summaries = await repository.getSummaries("CYP-123");
             expect(stubbedError).to.have.been.calledOnceWithExactly(
@@ -200,7 +200,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const descriptions = await repository.getDescriptions("CYP-123", "CYP-456", "CYP-789");
             expect(descriptions).to.deep.eq({
                 "CYP-123": "Very informative",
@@ -234,7 +234,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             await repository.getDescriptions("CYP-123", "CYP-789");
             const descriptions = await repository.getDescriptions("CYP-123", "CYP-456", "CYP-789");
             expect(descriptions).to.deep.eq({
@@ -263,7 +263,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const { stubbedError } = stubLogging();
             const descriptions = await repository.getDescriptions("CYP-123", "CYP-456", "CYP-789");
             expect(stubbedError).to.have.been.calledOnceWithExactly(
@@ -295,7 +295,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const { stubbedError } = stubLogging();
             const descriptions = await repository.getDescriptions("CYP-123");
             expect(stubbedError).to.have.been.calledOnceWithExactly(
@@ -328,7 +328,7 @@ describe("the cloud issue repository", () => {
                     };
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const testTypes = await repository.getTestTypes("CYP-123", "CYP-456", "CYP-789");
             expect(testTypes).to.deep.eq({
                 "CYP-123": "Cucumber",
@@ -362,7 +362,7 @@ describe("the cloud issue repository", () => {
                     throw new Error(`Unexpected argument: ${issueKeys}`);
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             await repository.getTestTypes("CYP-123", "CYP-789");
             const testTypes = await repository.getTestTypes("CYP-123", "CYP-456", "CYP-789");
             expect(testTypes).to.deep.eq({
@@ -394,7 +394,7 @@ describe("the cloud issue repository", () => {
                     throw new Error(`Unexpected argument: ${issueKeys}`);
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const { stubbedError } = stubLogging();
             const testTypes = await repository.getTestTypes("CYP-123", "CYP-456", "CYP-789");
             expect(stubbedError).to.have.been.calledOnceWithExactly(
@@ -424,7 +424,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Expected error");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const { stubbedError } = stubLogging();
             const testTypes = await repository.getTestTypes("CYP-123", "CYP-456", "CYP-789");
             expect(stubbedError).to.have.been.calledOnceWithExactly(
@@ -460,7 +460,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const labels = await repository.getLabels("CYP-123", "CYP-456", "CYP-789");
             expect(labels).to.deep.eq({
                 "CYP-123": ["A", "B", "C"],
@@ -494,7 +494,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             await repository.getLabels("CYP-123", "CYP-789");
             const labels = await repository.getLabels("CYP-123", "CYP-456", "CYP-789");
             expect(labels).to.deep.eq({
@@ -526,7 +526,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const { stubbedError } = stubLogging();
             const labels = await repository.getLabels("CYP-123", "CYP-456", "CYP-789");
             expect(stubbedError).to.have.been.calledOnceWithExactly(
@@ -558,7 +558,7 @@ describe("the cloud issue repository", () => {
                     throw new Error("Mock called unexpectedly");
                 },
             };
-            repository = new JiraRepository(jiraFieldRepository, mockedFieldFetcher, jiraOptions);
+            repository = new CachingJiraRepository(jiraFieldRepository, mockedFieldFetcher);
             const { stubbedError } = stubLogging();
             const labels = await repository.getLabels("CYP-123");
             expect(stubbedError).to.have.been.calledOnceWithExactly(

--- a/src/repository/jira/jiraRepository.ts
+++ b/src/repository/jira/jiraRepository.ts
@@ -1,29 +1,75 @@
 import { logError } from "../../logging/logging";
-import { InternalJiraOptions } from "../../types/plugin";
 import { StringMap } from "../../types/util";
 import { dedent } from "../../util/dedent";
 import { errorMessage } from "../../util/errors";
 import { IJiraFieldRepository } from "./fields/jiraFieldRepository";
 import { IJiraIssueFetcher, SupportedFields } from "./fields/jiraIssueFetcher";
 
+/**
+ * An interface describing a Jira repository, which provides methods for retrieving issue data such
+ * as summaries, descriptions, labels or test types.
+ */
 export interface IJiraRepository {
+    /**
+     * Retrieve the internal Jira ID of a field.
+     *
+     * @param fieldName - the field
+     * @returns the field ID
+     * @see https://confluence.atlassian.com/jirakb/how-to-find-id-for-custom-field-s-744522503.html
+     */
     getFieldId(fieldName: SupportedFields): Promise<string>;
-    getSummaries(...issueKeys: string[]): Promise<StringMap<string>>;
+    /**
+     * Retrieve the descriptions of all provided issues, represented through their Jira issue keys.
+     *
+     * @param issueKeys - the issue keys
+     * @returns a mapping of issue keys to issue descriptions
+     */
     getDescriptions(...issueKeys: string[]): Promise<StringMap<string>>;
-    getTestTypes(...issueKeys: string[]): Promise<StringMap<string>>;
+    /**
+     * Retrieve the labels of all provided issues, represented through their Jira issue keys.
+     *
+     * @param issueKeys - the issue keys
+     * @returns a mapping of issue keys to issue labels
+     */
     getLabels(...issueKeys: string[]): Promise<StringMap<string[]>>;
+    /**
+     * Retrieve the summaries of all provided issues, represented through their Jira issue keys.
+     *
+     * @param issueKeys - the issue keys
+     * @returns a mapping of issue keys to issue summaries
+     */
+    getSummaries(...issueKeys: string[]): Promise<StringMap<string>>;
+    /**
+     * Retrieve the test types of all provided test issues, represented through their Jira issue
+     * keys.
+     *
+     * @param issueKeys - the issue keys
+     * @returns a mapping of issue keys to test issue types
+     * @see https://docs.getxray.app/display/ON/Enabling+Xray+Issue+Types
+     */
+    getTestTypes(...issueKeys: string[]): Promise<StringMap<string>>;
 }
 
-export class JiraRepository implements IJiraRepository {
+/**
+ * A Jira repository which caches retrieved data. Caching means that live issue information is only
+ * retrieved for the first request. All subsequent accesses will then return the cached value.
+ */
+export class CachingJiraRepository implements IJiraRepository {
     private readonly summaries: StringMap<string> = {};
     private readonly descriptions: StringMap<string> = {};
     private readonly testTypes: StringMap<string> = {};
     private readonly labels: StringMap<string[]> = {};
 
+    /**
+     * Construct a new caching Jira repository. It relies on an internal field repository and an
+     * issue data fetcher for information retrieval.
+     *
+     * @param jiraFieldRepository - the Jira field repository
+     * @param jiraIssueFetcher - the Jira issue fetcher
+     */
     constructor(
         protected readonly jiraFieldRepository: IJiraFieldRepository,
-        protected readonly jiraFieldFetcher: IJiraIssueFetcher,
-        protected readonly jiraOptions: InternalJiraOptions
+        protected readonly jiraIssueFetcher: IJiraIssueFetcher
     ) {}
 
     public async getFieldId(fieldName: SupportedFields): Promise<string> {
@@ -35,7 +81,7 @@ export class JiraRepository implements IJiraRepository {
         try {
             result = await this.mergeRemainingFields(
                 this.summaries,
-                this.jiraFieldFetcher.fetchSummaries,
+                this.jiraIssueFetcher.fetchSummaries,
                 ...issueKeys
             );
             const missingSummaries: string[] = issueKeys.filter(
@@ -66,7 +112,7 @@ export class JiraRepository implements IJiraRepository {
         try {
             result = await this.mergeRemainingFields(
                 this.descriptions,
-                this.jiraFieldFetcher.fetchDescriptions,
+                this.jiraIssueFetcher.fetchDescriptions,
                 ...issueKeys
             );
             const missingDescriptions: string[] = issueKeys.filter(
@@ -97,7 +143,7 @@ export class JiraRepository implements IJiraRepository {
         try {
             result = await this.mergeRemainingFields(
                 this.testTypes,
-                this.jiraFieldFetcher.fetchTestTypes,
+                this.jiraIssueFetcher.fetchTestTypes,
                 ...issueKeys
             );
             const missingTestTypes: string[] = issueKeys.filter(
@@ -128,7 +174,7 @@ export class JiraRepository implements IJiraRepository {
         try {
             result = await this.mergeRemainingFields(
                 this.labels,
-                this.jiraFieldFetcher.fetchLabels,
+                this.jiraIssueFetcher.fetchLabels,
                 ...issueKeys
             );
             const missingLabels: string[] = issueKeys.filter(

--- a/src/repository/jira/jiraRepository.ts
+++ b/src/repository/jira/jiraRepository.ts
@@ -1,5 +1,5 @@
 import { logError } from "../../logging/logging";
-import { InternalJiraOptions, JiraFieldIds } from "../../types/plugin";
+import { InternalJiraOptions } from "../../types/plugin";
 import { StringMap } from "../../types/util";
 import { dedent } from "../../util/dedent";
 import { errorMessage } from "../../util/errors";
@@ -7,7 +7,7 @@ import { IJiraFieldRepository } from "./fields/jiraFieldRepository";
 import { IJiraIssueFetcher, SupportedFields } from "./fields/jiraIssueFetcher";
 
 export interface IJiraRepository {
-    getFieldId(fieldName: SupportedFields, optionName: keyof JiraFieldIds): Promise<string>;
+    getFieldId(fieldName: SupportedFields): Promise<string>;
     getSummaries(...issueKeys: string[]): Promise<StringMap<string>>;
     getDescriptions(...issueKeys: string[]): Promise<StringMap<string>>;
     getTestTypes(...issueKeys: string[]): Promise<StringMap<string>>;

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,7 +1,7 @@
 import { IPreprocessorConfiguration } from "@badeball/cypress-cucumber-preprocessor";
 import { JiraClient } from "../client/jira/jiraClient";
 import { XrayClient } from "../client/xray/xrayClient";
-import { JiraRepository } from "../repository/jira/jiraRepository";
+import { CachingJiraRepository } from "../repository/jira/jiraRepository";
 import { IIssueTypeDetails } from "./jira/responses/issueTypeDetails";
 
 export interface Options {
@@ -358,7 +358,7 @@ export interface ClientCombination {
     kind: "server" | "cloud";
     jiraClient: JiraClient;
     xrayClient: XrayClient;
-    jiraRepository: JiraRepository;
+    jiraRepository: CachingJiraRepository;
 }
 
 export interface PluginContext {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,6 +1,6 @@
 import { IPreprocessorConfiguration } from "@badeball/cypress-cucumber-preprocessor";
-import { JiraClient } from "../client/jira/jiraClient";
-import { XrayClient } from "../client/xray/xrayClient";
+import { IJiraClient } from "../client/jira/jiraClient";
+import { IXrayClient } from "../client/xray/xrayClient";
 import { IJiraRepository } from "../repository/jira/jiraRepository";
 import { IIssueTypeDetails } from "./jira/responses/issueTypeDetails";
 
@@ -356,8 +356,8 @@ export interface InternalOptions {
  */
 export interface ClientCombination {
     kind: "server" | "cloud";
-    jiraClient: JiraClient;
-    xrayClient: XrayClient;
+    jiraClient: IJiraClient;
+    xrayClient: IXrayClient;
     jiraRepository: IJiraRepository;
 }
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,7 +1,7 @@
 import { IPreprocessorConfiguration } from "@badeball/cypress-cucumber-preprocessor";
 import { JiraClient } from "../client/jira/jiraClient";
 import { XrayClient } from "../client/xray/xrayClient";
-import { CachingJiraRepository } from "../repository/jira/jiraRepository";
+import { IJiraRepository } from "../repository/jira/jiraRepository";
 import { IIssueTypeDetails } from "./jira/responses/issueTypeDetails";
 
 export interface Options {
@@ -358,7 +358,7 @@ export interface ClientCombination {
     kind: "server" | "cloud";
     jiraClient: JiraClient;
     xrayClient: XrayClient;
-    jiraRepository: CachingJiraRepository;
+    jiraRepository: IJiraRepository;
 }
 
 export interface PluginContext {

--- a/src/types/xray/requests/importExecutionCucumberMultipart.ts
+++ b/src/types/xray/requests/importExecutionCucumberMultipart.ts
@@ -1,7 +1,7 @@
 import { ICucumberMultipartInfo } from "./importExecutionCucumberMultipartInfo";
 
 /*
- * There is unfortunately no official Cucumber JSON report scheme available anywhere, as stated
+ * There unfortunately is no official Cucumber JSON report scheme available anywhere, as stated
  * here: https://github.com/cucumber/messages#lack-of-a-schema
  *
  * Therefore, the types in here are a mix of the following sources:


### PR DESCRIPTION
There was a distinct lack of TSDoc. Also, some class members were not necessary anymore. Lastly, some functions were badly named.