### PR TITLE
Add `skipLibCheck` compiler option

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -23,3 +23,7 @@ jobs:
         run: npm run test
       - name: Run ESLint
         run: npm run eslint
+      - name: Check if skipLibCheck is still needed
+        # https://github.com/Qytera-Gmbh/cypress-xray-plugin/pull/171#issuecomment-1763836002
+        run: npx tsc --project tsconfigBuild.json --skipLibCheck false --noEmit
+        continue-on-error: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "sinon": "^17.0.1",
                 "sinon-chai": "^3.7.0",
                 "ts-node": "^10.9.1",
-                "typescript": "^5.1.6"
+                "typescript": "^5.3.2"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -7840,9 +7840,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+            "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
             "devOptional": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.1.6"
+        "typescript": "^5.3.2"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,16 @@
     "include": ["**/*.ts"],
     "exclude": ["node_modules/", "dist/"],
     "compilerOptions": {
-        "target": "ESNext",
-        "module": "CommonJS",
-        "declaration": true,
-        "outDir": "dist",
-        "esModuleInterop": true,
-        "moduleResolution": "Node",
-        "lib": ["ESNext", "DOM"],
-        "types": ["cypress", "node"],
         "allowJs": true,
-        "strict": true
+        "declaration": true,
+        "esModuleInterop": true,
+        "lib": ["ESNext", "DOM"],
+        "module": "CommonJS",
+        "moduleResolution": "Node",
+        "outDir": "dist",
+        "skipLibCheck": true,
+        "strict": true,
+        "target": "ESNext",
+        "types": ["cypress", "node"],
     }
 }


### PR DESCRIPTION
Adresses #171. Adds `skipLibCheck: true` to the typescript configuration options. Also adds an extra CI check to continuously monitor if this option is really still required.