### PR TITLE
Hide initialization error messages if the plugin is disabled

### DIFF
--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -7,7 +7,7 @@ import { JiraClientServer } from "./client/jira/jiraClientServer";
 import { XrayClientServer } from "./client/xray/xrayClientServer";
 import * as context from "./context";
 import * as hooks from "./hooks";
-import { addXrayResultUpload, configureXrayPlugin, syncFeatureFile } from "./plugin";
+import { addXrayResultUpload, configureXrayPlugin, resetPlugin, syncFeatureFile } from "./plugin";
 import { CachingJiraFieldRepository } from "./repository/jira/fields/jiraFieldRepository";
 import { JiraIssueFetcher } from "./repository/jira/fields/jiraIssueFetcher";
 import { CachingJiraRepository } from "./repository/jira/jiraRepository";
@@ -51,7 +51,7 @@ describe("the plugin", () => {
                 jiraRepository: jiraRepository,
             },
         };
-        context.clearPluginContext();
+        resetPlugin();
     });
 
     describe("configureXrayPlugin", () => {
@@ -210,11 +210,11 @@ describe("the plugin", () => {
                 const beforeRunDetails: Cypress.BeforeRunDetails = JSON.parse(
                     fs.readFileSync("./test/resources/beforeRunMixed.json", "utf-8")
                 );
-                const { stubbedError } = stubLogging();
+                const { stubbedWarning } = stubLogging();
                 await addXrayResultUpload(
                     mockedCypressEventEmitter("before:run", beforeRunDetails)
                 );
-                expect(stubbedError).to.have.been.calledWith(
+                expect(stubbedWarning).to.have.been.calledWith(
                     dedent(`
                         Skipping before:run hook: Plugin misconfigured: configureXrayPlugin() was not called
 
@@ -275,10 +275,10 @@ describe("the plugin", () => {
                 const afterRunResult: CypressCommandLine.CypressRunResult = JSON.parse(
                     fs.readFileSync("./test/resources/runResult.json", "utf-8")
                 );
-                const { stubbedError } = stubLogging();
+                const { stubbedWarning } = stubLogging();
                 await addXrayResultUpload(mockedCypressEventEmitter("after:run", afterRunResult));
-                expect(stubbedError).to.have.been.calledOnce;
-                expect(stubbedError).to.have.been.calledWith(
+                expect(stubbedWarning).to.have.been.calledOnce;
+                expect(stubbedWarning).to.have.been.calledWith(
                     dedent(`
                         Skipping after:run hook: Plugin misconfigured: configureXrayPlugin() was not called
 
@@ -366,10 +366,10 @@ describe("the plugin", () => {
         });
 
         it("displays errors if the plugin was not configured", async () => {
-            const { stubbedError } = stubLogging();
+            const { stubbedWarning } = stubLogging();
             await syncFeatureFile(file);
-            expect(stubbedError).to.have.been.calledOnce;
-            expect(stubbedError).to.have.been.calledWith(
+            expect(stubbedWarning).to.have.been.calledOnce;
+            expect(stubbedWarning).to.have.been.calledWith(
                 dedent(`
                     Skipping file:preprocessor hook: Plugin misconfigured: configureXrayPlugin() was not called
 

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -206,7 +206,7 @@ describe("the plugin", () => {
 
     describe("addXrayResultUpload", () => {
         describe("on before:run", () => {
-            it("displays errors if the plugin was not configured", async () => {
+            it("displays warnings if the plugin was not configured", async () => {
                 const beforeRunDetails: Cypress.BeforeRunDetails = JSON.parse(
                     fs.readFileSync("./test/resources/beforeRunMixed.json", "utf-8")
                 );
@@ -221,6 +221,21 @@ describe("the plugin", () => {
                         Make sure your project is set up correctly: https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/introduction/
                     `)
                 );
+            });
+
+            it("does not display a warning if the plugin was configured but disabled", async () => {
+                const beforeRunDetails: Cypress.BeforeRunDetails = JSON.parse(
+                    fs.readFileSync("./test/resources/beforeRunMixed.json", "utf-8")
+                );
+                const { stubbedWarning } = stubLogging();
+                await configureXrayPlugin(config, {
+                    jira: { projectKey: "CYP", url: "https://example.org" },
+                    plugin: { enabled: false },
+                });
+                await addXrayResultUpload(
+                    mockedCypressEventEmitter("before:run", beforeRunDetails)
+                );
+                expect(stubbedWarning).to.not.have.been.called;
             });
 
             it("does nothing if disabled", async () => {
@@ -271,7 +286,7 @@ describe("the plugin", () => {
         });
 
         describe("on after:run", () => {
-            it("displays errors if the plugin was not configured", async () => {
+            it("displays warnings if the plugin was not configured", async () => {
                 const afterRunResult: CypressCommandLine.CypressRunResult = JSON.parse(
                     fs.readFileSync("./test/resources/runResult.json", "utf-8")
                 );
@@ -285,6 +300,19 @@ describe("the plugin", () => {
                         Make sure your project is set up correctly: https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/introduction/
                     `)
                 );
+            });
+
+            it("does not display a warning if the plugin was configured but disabled", async () => {
+                const afterRunResult: CypressCommandLine.CypressRunResult = JSON.parse(
+                    fs.readFileSync("./test/resources/runResult.json", "utf-8")
+                );
+                const { stubbedWarning } = stubLogging();
+                await configureXrayPlugin(config, {
+                    jira: { projectKey: "CYP", url: "https://example.org" },
+                    plugin: { enabled: false },
+                });
+                await addXrayResultUpload(mockedCypressEventEmitter("after:run", afterRunResult));
+                expect(stubbedWarning).to.not.have.been.called;
             });
 
             it("does not display an error for failed runs if disabled", async () => {
@@ -365,7 +393,7 @@ describe("the plugin", () => {
             };
         });
 
-        it("displays errors if the plugin was not configured", async () => {
+        it("displays warnings if the plugin was not configured", async () => {
             const { stubbedWarning } = stubLogging();
             await syncFeatureFile(file);
             expect(stubbedWarning).to.have.been.calledOnce;
@@ -376,6 +404,16 @@ describe("the plugin", () => {
                     Make sure your project is set up correctly: https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/introduction/
                 `)
             );
+        });
+
+        it("does not display a warning if the plugin was configured but disabled", async () => {
+            const { stubbedWarning } = stubLogging();
+            await configureXrayPlugin(config, {
+                jira: { projectKey: "CYP", url: "https://example.org" },
+                plugin: { enabled: false },
+            });
+            await syncFeatureFile(file);
+            expect(stubbedWarning).to.not.have.been.called;
         });
 
         it("does not do anything if disabled", async () => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,5 @@
 import {
+    clearPluginContext,
     getPluginContext,
     initClients,
     initCucumberOptions,
@@ -15,7 +16,36 @@ import { InternalOptions, InternalPluginOptions, Options } from "./types/plugin"
 import { dedent } from "./util/dedent";
 import { HELP } from "./util/help";
 
-export async function configureXrayPlugin(config: Cypress.PluginConfigOptions, options: Options) {
+let canShowInitializationWarning: boolean = true;
+
+/**
+ * Resets the plugin including its context.
+ */
+export function resetPlugin(): void {
+    clearPluginContext();
+    canShowInitializationWarning = true;
+}
+
+/**
+ * Configures the plugin. The plugin will inspect all environment variables passed in
+ * {@link Cypress.PluginConfigOptions.env | `config.env`} and merge them with the ones provided in
+ * `options`.
+ *
+ * Note: Environment variables always take precedence over values specified in `options`.
+ *
+ * Other Cypress configuration values which the plugin typically accesses are the Cypress version or
+ * the project root directory.
+ *
+ * @param config - the Cypress configuration
+ * @param options - the plugin options
+ *
+ * @see https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/guides/uploadTestResults/#setup
+ */
+export async function configureXrayPlugin(
+    config: Cypress.PluginConfigOptions,
+    options: Options
+): Promise<void> {
+    canShowInitializationWarning = false;
     // Resolve these before all other options for correct enabledness.
     const pluginOptions: InternalPluginOptions = initPluginOptions(config.env, options.plugin);
     if (!pluginOptions.enabled) {
@@ -46,11 +76,21 @@ export async function configureXrayPlugin(config: Cypress.PluginConfigOptions, o
     });
 }
 
-export async function addXrayResultUpload(on: Cypress.PluginEvents) {
+/**
+ * Enables Cypress test results upload to Xray. This method will register several upload hooks under
+ * the passed plugin events.
+ *
+ * @param on - the Cypress plugin events
+ *
+ * @see https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/guides/uploadTestResults/
+ */
+export async function addXrayResultUpload(on: Cypress.PluginEvents): Promise<void> {
     on("before:run", async (runDetails: Cypress.BeforeRunDetails) => {
         const context = getPluginContext();
         if (!context) {
-            logInitializationError("before:run");
+            if (canShowInitializationWarning) {
+                logInitializationWarning("before:run");
+            }
             return;
         }
         if (!context.internal.plugin.enabled) {
@@ -70,7 +110,9 @@ export async function addXrayResultUpload(on: Cypress.PluginEvents) {
         ) => {
             const context = getPluginContext();
             if (!context) {
-                logInitializationError("after:run");
+                if (canShowInitializationWarning) {
+                    logInitializationWarning("after:run");
+                }
                 return;
             }
             if (!context.internal.plugin.enabled) {
@@ -101,10 +143,20 @@ export async function addXrayResultUpload(on: Cypress.PluginEvents) {
     );
 }
 
+/**
+ * Attempts to synchronize the Cucumber feature file with Xray. If the filename does not end with
+ * the configured {@link https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/cucumber/#featurefileextension | feature file extension},
+ * this method does not upload anything to Xray.
+ *
+ * @param file - the Cypress file object
+ * @returns the unmodified file's path
+ */
 export async function syncFeatureFile(file: Cypress.FileObject): Promise<string> {
     const context = getPluginContext();
     if (!context) {
-        logInitializationError("file:preprocessor");
+        if (canShowInitializationWarning) {
+            logInitializationWarning("file:preprocessor");
+        }
         return file.filePath;
     }
     if (!context.internal.plugin.enabled) {
@@ -121,9 +173,9 @@ export async function syncFeatureFile(file: Cypress.FileObject): Promise<string>
     );
 }
 
-function logInitializationError(hook: "before:run" | "after:run" | "file:preprocessor"): void {
+function logInitializationWarning(hook: "before:run" | "after:run" | "file:preprocessor"): void {
     // Do not throw in case someone does not want the plugin to run but forgot to remove a hook.
-    logError(
+    logWarning(
         dedent(`
             Skipping ${hook} hook: Plugin misconfigured: configureXrayPlugin() was not called
 


### PR DESCRIPTION
Addresses #271. When the plugin has been properly configured, it will not display initialization errors anymore if it's disabled using either:

```ts
{
  plugin: {
    enabled: false
  }
}
```

or:

```sh
npx cypress run --env PLUGIN_ENABLED=false
```