### PR TITLE
Replace limited OpenSSL options with full HTTP configurability

### DIFF
--- a/index.spec.ts
+++ b/index.spec.ts
@@ -64,15 +64,15 @@ describe("the plugin exports should work", () => {
             };
             expect(options.plugin).to.exist;
         });
-        it("openSSL", () => {
+        it("http", () => {
             const options: CypressXrayPluginOptions = {
                 jira: {
                     projectKey: "CYP-123",
                     url: "https://example.org",
                 },
-                ["openSSL"]: {},
+                http: {},
             };
-            expect(options.openSSL).to.exist;
+            expect(options.http).to.exist;
         });
     });
 });

--- a/src/authentication/credentials.ts
+++ b/src/authentication/credentials.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse } from "axios";
-import { REST } from "../https/requests";
+import { AxiosRestClient } from "../https/requests";
 import { LOG, Level } from "../logging/logging";
 import { StringMap } from "../types/util";
 import { encode } from "../util/base64";
@@ -88,11 +88,13 @@ export class JwtCredentials implements HttpCredentials {
      * @param clientId - the client ID
      * @param clientSecret - the client secret
      * @param authenticationUrl - the authentication URL/token endpoint
+     * @param httpClient - the HTTP client to use for fetching the token
      */
     constructor(
         private readonly clientId: string,
         private readonly clientSecret: string,
-        private readonly authenticationUrl: string
+        private readonly authenticationUrl: string,
+        private readonly httpClient: AxiosRestClient
     ) {
         this.token = undefined;
     }
@@ -125,7 +127,7 @@ export class JwtCredentials implements HttpCredentials {
                 });
                 try {
                     LOG.message(Level.INFO, `Authenticating to: ${this.authenticationUrl}...`);
-                    const tokenResponse: AxiosResponse<string> = await REST.post(
+                    const tokenResponse: AxiosResponse<string> = await this.httpClient.post(
                         this.authenticationUrl,
                         {
                             ["client_id"]: this.clientId,

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,4 +1,5 @@
 import { HttpCredentials } from "../authentication/credentials";
+import { AxiosRestClient } from "../https/requests";
 import { LOG, Level } from "../logging/logging";
 import { startInterval } from "../util/time";
 
@@ -14,16 +15,22 @@ export abstract class Client {
      * The credentials to use for authentication.
      */
     protected readonly credentials: HttpCredentials;
+    /**
+     * The HTTP client to use for dispatching requests.
+     */
+    protected readonly httpClient: AxiosRestClient;
 
     /**
      * Construct a new client using the provided credentials.
      *
      * @param apiBaseUrl - the base URL for all HTTP requests
      * @param credentials - the credentials to use during authentication
+     * @param httpClient - the HTTP client to use for dispatching requests
      */
-    constructor(apiBaseUrl: string, credentials: HttpCredentials) {
+    constructor(apiBaseUrl: string, credentials: HttpCredentials, httpClient: AxiosRestClient) {
         this.apiBaseUrl = apiBaseUrl;
         this.credentials = credentials;
+        this.httpClient = httpClient;
     }
 
     /**

--- a/src/client/jira/jiraClient.spec.ts
+++ b/src/client/jira/jiraClient.spec.ts
@@ -30,11 +30,13 @@ describe("the jira clients", () => {
                     clientType === "server"
                         ? new JiraClientServer(
                               "https://example.org",
-                              new BasicAuthCredentials("user", "token")
+                              new BasicAuthCredentials("user", "token"),
+                              restClient
                           )
                         : new JiraClientCloud(
                               "https://example.org",
-                              new BasicAuthCredentials("user", "token")
+                              new BasicAuthCredentials("user", "token"),
+                              restClient
                           );
             });
 

--- a/src/client/jira/jiraClient.ts
+++ b/src/client/jira/jiraClient.ts
@@ -1,7 +1,6 @@
 import { AxiosResponse } from "axios";
 import FormData from "form-data";
 import fs from "fs";
-import { REST } from "../../https/requests";
 import { LOG, Level } from "../../logging/logging";
 import { SearchRequest } from "../../types/jira/requests/search";
 import { Attachment } from "../../types/jira/responses/attachment";
@@ -113,7 +112,7 @@ export abstract class AbstractJiraClient extends Client implements JiraClient {
             LOG.message(Level.DEBUG, "Attaching files:", ...files);
             const progressInterval = this.startResponseInterval(this.apiBaseUrl);
             try {
-                const response: AxiosResponse<Attachment[]> = await REST.post(
+                const response: AxiosResponse<Attachment[]> = await this.httpClient.post(
                     this.getUrlAddAttachment(issueIdOrKey),
                     form,
                     {
@@ -147,7 +146,7 @@ export abstract class AbstractJiraClient extends Client implements JiraClient {
             LOG.message(Level.DEBUG, "Getting issue types...");
             const progressInterval = this.startResponseInterval(this.apiBaseUrl);
             try {
-                const response: AxiosResponse<IssueTypeDetails[]> = await REST.get(
+                const response: AxiosResponse<IssueTypeDetails[]> = await this.httpClient.get(
                     this.getUrlGetIssueTypes(),
                     {
                         headers: {
@@ -194,7 +193,7 @@ export abstract class AbstractJiraClient extends Client implements JiraClient {
             LOG.message(Level.DEBUG, "Getting fields...");
             const progressInterval = this.startResponseInterval(this.apiBaseUrl);
             try {
-                const response: AxiosResponse<FieldDetail[]> = await REST.get(
+                const response: AxiosResponse<FieldDetail[]> = await this.httpClient.get(
                     this.getUrlGetFields(),
                     {
                         headers: {
@@ -239,7 +238,7 @@ export abstract class AbstractJiraClient extends Client implements JiraClient {
                         ...request,
                         startAt: startAt,
                     };
-                    const response: AxiosResponse<SearchResults> = await REST.post(
+                    const response: AxiosResponse<SearchResults> = await this.httpClient.post(
                         this.getUrlPostSearch(),
                         paginatedRequest,
                         {
@@ -277,7 +276,7 @@ export abstract class AbstractJiraClient extends Client implements JiraClient {
             LOG.message(Level.DEBUG, "Editing issue...");
             const progressInterval = this.startResponseInterval(this.apiBaseUrl);
             try {
-                await REST.put(this.getUrlEditIssue(issueIdOrKey), issueUpdateData, {
+                await this.httpClient.put(this.getUrlEditIssue(issueIdOrKey), issueUpdateData, {
                     headers: {
                         ...header,
                     },

--- a/src/client/jira/jiraClientCloud.spec.ts
+++ b/src/client/jira/jiraClientCloud.spec.ts
@@ -1,13 +1,13 @@
-/// <reference types="cypress" />
-
 import { expect } from "chai";
+import { getMockedRestClient } from "../../../test/mocks";
 import { BasicAuthCredentials } from "../../authentication/credentials";
 import { JiraClientCloud } from "./jiraClientCloud";
 
 describe("the jira cloud client", () => {
     const client: JiraClientCloud = new JiraClientCloud(
         "https://example.org",
-        new BasicAuthCredentials("user", "token")
+        new BasicAuthCredentials("user", "token"),
+        getMockedRestClient()
     );
 
     describe("the urls", () => {

--- a/src/client/jira/jiraClientServer.spec.ts
+++ b/src/client/jira/jiraClientServer.spec.ts
@@ -1,13 +1,13 @@
-/// <reference types="cypress" />
-
 import { expect } from "chai";
+import { getMockedRestClient } from "../../../test/mocks";
 import { BasicAuthCredentials } from "../../authentication/credentials";
 import { JiraClientServer } from "./jiraClientServer";
 
 describe("the jira server client", () => {
     const client: JiraClientServer = new JiraClientServer(
         "https://example.org",
-        new BasicAuthCredentials("user", "token")
+        new BasicAuthCredentials("user", "token"),
+        getMockedRestClient()
     );
 
     describe("the urls", () => {

--- a/src/client/xray/xrayClient.spec.ts
+++ b/src/client/xray/xrayClient.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { getMockedJwtCredentials, getMockedLogger } from "../../../test/mocks";
+import { getMockedJwtCredentials, getMockedLogger, getMockedRestClient } from "../../../test/mocks";
 import { BasicAuthCredentials } from "../../authentication/credentials";
 import { Level } from "../../logging/logging";
 import { AbstractXrayClient } from "./xrayClient";
@@ -18,9 +18,10 @@ describe("the xray clients", () => {
                     clientType === "server"
                         ? new XrayClientServer(
                               "https://example.org",
-                              new BasicAuthCredentials("user", "token")
+                              new BasicAuthCredentials("user", "token"),
+                              getMockedRestClient()
                           )
-                        : new XrayClientCloud(credentials);
+                        : new XrayClientCloud(credentials, getMockedRestClient());
             });
 
             describe("import execution", () => {

--- a/src/client/xray/xrayClient.ts
+++ b/src/client/xray/xrayClient.ts
@@ -1,7 +1,7 @@
 import { AxiosResponse, HttpStatusCode, isAxiosError } from "axios";
 import FormData from "form-data";
 import fs from "fs";
-import { REST, RequestConfigPost } from "../../https/requests";
+import { RequestConfigPost } from "../../https/requests";
 import { LOG, Level } from "../../logging/logging";
 import { XrayTestExecutionResults } from "../../types/xray/importTestExecutionResults";
 import { CucumberMultipartFeature } from "../../types/xray/requests/importExecutionCucumberMultipart";
@@ -94,7 +94,7 @@ export abstract class AbstractXrayClient extends Client implements XrayClient {
             try {
                 const response: AxiosResponse<
                     ImportExecutionResponseServer | ImportExecutionResponseCloud
-                > = await REST.post(this.getUrlImportExecution(), execution, {
+                > = await this.httpClient.post(this.getUrlImportExecution(), execution, {
                     headers: {
                         ...authorizationHeader,
                     },
@@ -120,7 +120,7 @@ export abstract class AbstractXrayClient extends Client implements XrayClient {
             LOG.message(Level.DEBUG, "Exporting Cucumber tests...");
             const progressInterval = this.startResponseInterval(this.apiBaseUrl);
             try {
-                const response: AxiosResponse<string> = await REST.get(
+                const response: AxiosResponse<string> = await this.httpClient.get(
                     this.getUrlExportCucumber(keys, filter),
                     {
                         headers: {
@@ -165,12 +165,16 @@ export abstract class AbstractXrayClient extends Client implements XrayClient {
 
                 const response: AxiosResponse<
                     ImportFeatureResponseServer | ImportFeatureResponseCloud
-                > = await REST.post(this.getUrlImportFeature(projectKey, projectId, source), form, {
-                    headers: {
-                        ...authorizationHeader,
-                        ...form.getHeaders(),
-                    },
-                });
+                > = await this.httpClient.post(
+                    this.getUrlImportFeature(projectKey, projectId, source),
+                    form,
+                    {
+                        headers: {
+                            ...authorizationHeader,
+                            ...form.getHeaders(),
+                        },
+                    }
+                );
                 return this.handleResponseImportFeature(response.data);
             } finally {
                 clearInterval(progressInterval);
@@ -220,7 +224,7 @@ export abstract class AbstractXrayClient extends Client implements XrayClient {
             try {
                 const response: AxiosResponse<
                     ImportExecutionResponseServer | ImportExecutionResponseCloud
-                > = await REST.post(request.url, request.data, request.config);
+                > = await this.httpClient.post(request.url, request.data, request.config);
                 const key = this.handleResponseImportExecutionCucumberMultipart(response.data);
                 LOG.message(
                     Level.DEBUG,

--- a/src/client/xray/xrayClientCloud.spec.ts
+++ b/src/client/xray/xrayClientCloud.spec.ts
@@ -21,8 +21,8 @@ describe("the xray cloud client", () => {
     beforeEach(() => {
         const credentials = getMockedJwtCredentials();
         credentials.getAuthorizationHeader.resolves({ ["Authorization"]: "ey12345" });
-        client = new XrayClientCloud(credentials);
         restClient = getMockedRestClient();
+        client = new XrayClientCloud(credentials, restClient);
     });
 
     describe("import execution", () => {

--- a/src/client/xray/xrayClientCloud.ts
+++ b/src/client/xray/xrayClientCloud.ts
@@ -1,7 +1,7 @@
 import { AxiosResponse } from "axios";
 import FormData from "form-data";
 import { JwtCredentials } from "../../authentication/credentials";
-import { RequestConfigPost, REST } from "../../https/requests";
+import { AxiosRestClient, RequestConfigPost } from "../../https/requests";
 import { Level, LOG } from "../../logging/logging";
 import { StringMap } from "../../types/util";
 import { CucumberMultipartFeature } from "../../types/xray/requests/importExecutionCucumberMultipart";
@@ -51,9 +51,10 @@ export class XrayClientCloud extends AbstractXrayClient implements HasTestTypes 
      * Construct a new Xray cloud client using the provided credentials.
      *
      * @param credentials - the credentials to use during authentication
+     * @param httpClient - the HTTP client to use for dispatching requests
      */
-    constructor(credentials: JwtCredentials) {
-        super(XrayClientCloud.URL, credentials);
+    constructor(credentials: JwtCredentials, httpClient: AxiosRestClient) {
+        super(XrayClientCloud.URL, credentials, httpClient);
     }
 
     public getUrlImportExecution(): string {
@@ -135,7 +136,7 @@ export class XrayClientCloud extends AbstractXrayClient implements HasTestTypes 
                         },
                     };
                     const response: AxiosResponse<GetTestsResponse<GetTestsJiraData>> =
-                        await REST.post(XrayClientCloud.URL_GRAPHQL, paginatedRequest, {
+                        await this.httpClient.post(XrayClientCloud.URL_GRAPHQL, paginatedRequest, {
                             headers: {
                                 ...authorizationHeader,
                             },

--- a/src/client/xray/xrayClientServer.spec.ts
+++ b/src/client/xray/xrayClientServer.spec.ts
@@ -12,14 +12,16 @@ import { dedent } from "../../util/dedent";
 import { XrayClientServer } from "./xrayClientServer";
 
 describe("the xray server client", () => {
-    const client: XrayClientServer = new XrayClientServer(
-        "https://example.org",
-        new BasicAuthCredentials("user", "xyz")
-    );
     let restClient: SinonStubbedInstance<AxiosRestClient>;
+    let client: XrayClientServer;
 
     beforeEach(() => {
         restClient = getMockedRestClient();
+        client = new XrayClientServer(
+            "https://example.org",
+            new BasicAuthCredentials("user", "xyz"),
+            restClient
+        );
     });
 
     describe("import execution", () => {

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -19,6 +19,7 @@ import * as dependencies from "./dependencies";
 import { AxiosRestClient } from "./https/requests";
 import { Level } from "./logging/logging";
 import {
+    HttpOptions,
     InternalCucumberOptions,
     InternalHttpOptions,
     InternalJiraOptions,
@@ -1057,23 +1058,17 @@ describe("the plugin context configuration", () => {
         it("creates a single client by default", () => {
             const httpClients = initHttpClients(undefined, undefined);
             expect(httpClients.jira).to.eq(httpClients.xray);
-            expect(httpClients.jira).to.deep.eq(
-                new AxiosRestClient({ debug: undefined, http: undefined })
-            );
+            expect(httpClients.jira).to.deep.eq(new AxiosRestClient({ debug: undefined }));
         });
         it("sets debugging to true if enabled", () => {
             const httpClients = initHttpClients({ debug: true }, undefined);
             expect(httpClients.jira).to.eq(httpClients.xray);
-            expect(httpClients.jira).to.deep.eq(
-                new AxiosRestClient({ debug: true, http: undefined })
-            );
+            expect(httpClients.jira).to.deep.eq(new AxiosRestClient({ debug: true }));
         });
         it("sets debugging to false if disabled", () => {
             const httpClients = initHttpClients({ debug: false }, undefined);
             expect(httpClients.jira).to.eq(httpClients.xray);
-            expect(httpClients.jira).to.deep.eq(
-                new AxiosRestClient({ debug: false, http: undefined })
-            );
+            expect(httpClients.jira).to.deep.eq(new AxiosRestClient({ debug: false }));
         });
         it("creates a single client if empty options are passed", () => {
             const httpClients = initHttpClients(undefined, {});
@@ -1128,11 +1123,16 @@ describe("the plugin context configuration", () => {
             expect(httpClients.xray).to.deep.eq(
                 new AxiosRestClient({
                     debug: undefined,
-                    http: undefined,
+                    http: {},
                 })
             );
         });
         it("creates a different xray client if a xray config is passed", () => {
+            const x: HttpOptions = {
+                url: "abc",
+                jira: {},
+            };
+            console.log(x);
             const httpOptions: InternalHttpOptions = {
                 xray: {
                     proxy: {
@@ -1146,7 +1146,7 @@ describe("the plugin context configuration", () => {
             expect(httpClients.jira).to.deep.eq(
                 new AxiosRestClient({
                     debug: undefined,
-                    http: undefined,
+                    http: {},
                 })
             );
             expect(httpClients.xray).to.deep.eq(
@@ -1193,6 +1193,49 @@ describe("the plugin context configuration", () => {
                 new AxiosRestClient({
                     debug: undefined,
                     http: {
+                        proxy: {
+                            host: "https://example.org",
+                            port: 12345,
+                        },
+                    },
+                })
+            );
+        });
+        it("passes common http options to both clients", () => {
+            const httpOptions: InternalHttpOptions = {
+                timeout: 42,
+                jira: {
+                    proxy: {
+                        host: "http://localhost",
+                        port: 98765,
+                    },
+                },
+                xray: {
+                    proxy: {
+                        host: "https://example.org",
+                        port: 12345,
+                    },
+                },
+            };
+            const httpClients = initHttpClients(undefined, httpOptions);
+            expect(httpClients.jira).to.not.eq(httpClients.xray);
+            expect(httpClients.jira).to.deep.eq(
+                new AxiosRestClient({
+                    debug: undefined,
+                    http: {
+                        timeout: 42,
+                        proxy: {
+                            host: "http://localhost",
+                            port: 98765,
+                        },
+                    },
+                })
+            );
+            expect(httpClients.xray).to.deep.eq(
+                new AxiosRestClient({
+                    debug: undefined,
+                    http: {
+                        timeout: 42,
                         proxy: {
                             host: "https://example.org",
                             port: 12345,

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -12,7 +12,6 @@ import {
     initCucumberOptions,
     initJiraOptions,
     initPluginOptions,
-    initSslOptions,
     initXrayOptions,
 } from "./context";
 import * as dependencies from "./dependencies";
@@ -21,7 +20,6 @@ import {
     InternalCucumberOptions,
     InternalJiraOptions,
     InternalPluginOptions,
-    InternalSslOptions,
     InternalXrayOptions,
 } from "./types/plugin";
 import { dedent } from "./util/dedent";
@@ -157,16 +155,6 @@ describe("the plugin context configuration", () => {
                 });
                 it("uploadFeatures", () => {
                     expect(cucumberOptions?.uploadFeatures).to.eq(false);
-                });
-            });
-
-            describe("openSSL", () => {
-                const sslOptions: InternalSslOptions = initSslOptions({}, {});
-                it("openSSL", () => {
-                    expect(sslOptions.rootCAPath).to.eq(undefined);
-                });
-                it("secureOptions", () => {
-                    expect(sslOptions.secureOptions).to.eq(undefined);
                 });
             });
         });
@@ -528,27 +516,6 @@ describe("the plugin context configuration", () => {
                         }
                     );
                     expect(cucumberOptions?.uploadFeatures).to.eq(true);
-                });
-            });
-
-            describe("openSSL", () => {
-                it("rootCAPath", () => {
-                    const sslOptions = initSslOptions(
-                        {},
-                        {
-                            ["rootCAPath"]: "/path/to/cert.pem",
-                        }
-                    );
-                    expect(sslOptions.rootCAPath).to.eq("/path/to/cert.pem");
-                });
-                it("secureOptions", () => {
-                    const sslOptions = initSslOptions(
-                        {},
-                        {
-                            secureOptions: 42,
-                        }
-                    );
-                    expect(sslOptions.secureOptions).to.eq(42);
                 });
             });
         });
@@ -963,27 +930,6 @@ describe("the plugin context configuration", () => {
                         normalizeScreenshotNames: false,
                     });
                     expect(pluginOptions.normalizeScreenshotNames).to.be.true;
-                });
-            });
-            describe("openSSL", () => {
-                it("OPENSSL_ROOT_CA_PATH ", () => {
-                    const env = {
-                        ["OPENSSL_ROOT_CA_PATH"]: "/home/ssl/ca.pem",
-                    };
-                    const sslOptions = initSslOptions(env, {
-                        ["rootCAPath"]: "/a/b/c.pem",
-                    });
-                    expect(sslOptions.rootCAPath).to.eq("/home/ssl/ca.pem");
-                });
-
-                it("OPENSSL_SECURE_OPTIONS ", () => {
-                    const env = {
-                        ["OPENSSL_SECURE_OPTIONS"]: 415,
-                    };
-                    const sslOptions = initSslOptions(env, {
-                        secureOptions: 42,
-                    });
-                    expect(sslOptions.secureOptions).to.eq(415);
                 });
             });
         });

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,3 +1,4 @@
+import { AxiosRequestConfig } from "axios";
 import { BasicAuthCredentials, JwtCredentials, PatCredentials } from "./authentication/credentials";
 import { JiraClientCloud } from "./client/jira/jiraClientCloud";
 import { JiraClientServer } from "./client/jira/jiraClientServer";
@@ -9,6 +10,7 @@ import {
     importOptionalDependency,
 } from "./dependencies";
 import { ENV_NAMES } from "./env";
+import { AxiosRestClient } from "./https/requests";
 import { LOG, Level } from "./logging/logging";
 import { CachingJiraFieldRepository } from "./repository/jira/fields/jiraFieldRepository";
 import {
@@ -18,7 +20,9 @@ import {
 import { CachingJiraRepository } from "./repository/jira/jiraRepository";
 import {
     ClientCombination,
+    HttpClientCombination,
     InternalCucumberOptions,
+    InternalHttpOptions,
     InternalJiraOptions,
     InternalPluginOptions,
     InternalXrayOptions,
@@ -263,9 +267,42 @@ export async function initCucumberOptions(
     return undefined;
 }
 
+export function initHttpClients(
+    pluginOptions?: Pick<InternalPluginOptions, "debug">,
+    httpOptions?: InternalHttpOptions
+): HttpClientCombination {
+    if (httpOptions) {
+        if (!isAxiosConfig(httpOptions)) {
+            return {
+                jira: new AxiosRestClient({
+                    debug: pluginOptions?.debug,
+                    http: httpOptions.jira,
+                }),
+                xray: new AxiosRestClient({
+                    debug: pluginOptions?.debug,
+                    http: httpOptions.xray,
+                }),
+            };
+        }
+    }
+    const httpClient = new AxiosRestClient({
+        debug: pluginOptions?.debug,
+        http: httpOptions,
+    });
+    return {
+        jira: httpClient,
+        xray: httpClient,
+    };
+}
+
+function isAxiosConfig(config: InternalHttpOptions): config is AxiosRequestConfig {
+    return !("jira" in config || "xray" in config);
+}
+
 export async function initClients(
     jiraOptions: InternalJiraOptions,
-    env: Cypress.ObjectLike
+    env: Cypress.ObjectLike,
+    httpClients: HttpClientCombination
 ): Promise<ClientCombination> {
     if (!jiraOptions.url) {
         throw new Error(
@@ -288,8 +325,8 @@ export async function initClients(
             env[ENV_NAMES.authentication.jira.username] as string,
             env[ENV_NAMES.authentication.jira.apiToken] as string
         );
-        await pingJiraInstance(jiraOptions.url, credentials);
-        const jiraClient = new JiraClientCloud(jiraOptions.url, credentials);
+        await pingJiraInstance(jiraOptions.url, credentials, httpClients.jira);
+        const jiraClient = new JiraClientCloud(jiraOptions.url, credentials, httpClients.jira);
         if (
             ENV_NAMES.authentication.xray.clientId in env &&
             ENV_NAMES.authentication.xray.clientSecret in env
@@ -302,10 +339,11 @@ export async function initClients(
             const xrayCredentials = new JwtCredentials(
                 env[ENV_NAMES.authentication.xray.clientId] as string,
                 env[ENV_NAMES.authentication.xray.clientSecret] as string,
-                `${XrayClientCloud.URL}/authenticate`
+                `${XrayClientCloud.URL}/authenticate`,
+                httpClients.xray
             );
             await pingXrayCloud(xrayCredentials);
-            const xrayClient = new XrayClientCloud(xrayCredentials);
+            const xrayClient = new XrayClientCloud(xrayCredentials, httpClients.xray);
             const jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
             const jiraFieldFetcher = new CachingJiraIssueFetcherCloud(
                 jiraClient,
@@ -333,12 +371,12 @@ export async function initClients(
         const credentials = new PatCredentials(
             env[ENV_NAMES.authentication.jira.apiToken] as string
         );
-        await pingJiraInstance(jiraOptions.url, credentials);
-        const jiraClient = new JiraClientServer(jiraOptions.url, credentials);
+        await pingJiraInstance(jiraOptions.url, credentials, httpClients.jira);
+        const jiraClient = new JiraClientServer(jiraOptions.url, credentials, httpClients.jira);
         // Xray server authentication: no username, only token.
         LOG.message(Level.INFO, "Jira PAT found. Setting up Xray server PAT credentials");
-        await pingXrayServer(jiraOptions.url, credentials);
-        const xrayClient = new XrayClientServer(jiraOptions.url, credentials);
+        await pingXrayServer(jiraOptions.url, credentials, httpClients.xray);
+        const xrayClient = new XrayClientServer(jiraOptions.url, credentials, httpClients.xray);
         const jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
         const jiraFieldFetcher = new CachingJiraIssueFetcher(
             jiraClient,
@@ -364,14 +402,14 @@ export async function initClients(
             env[ENV_NAMES.authentication.jira.username] as string,
             env[ENV_NAMES.authentication.jira.password] as string
         );
-        await pingJiraInstance(jiraOptions.url, credentials);
-        const jiraClient = new JiraClientServer(jiraOptions.url, credentials);
+        await pingJiraInstance(jiraOptions.url, credentials, httpClients.jira);
+        const jiraClient = new JiraClientServer(jiraOptions.url, credentials, httpClients.jira);
         LOG.message(
             Level.INFO,
             "Jira username and password found. Setting up Xray server basic auth credentials"
         );
-        await pingXrayServer(jiraOptions.url, credentials);
-        const xrayClient = new XrayClientServer(jiraOptions.url, credentials);
+        await pingXrayServer(jiraOptions.url, credentials, httpClients.xray);
+        const xrayClient = new XrayClientServer(jiraOptions.url, credentials, httpClients.xray);
         const jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
         const jiraFieldFetcher = new CachingJiraIssueFetcher(
             jiraClient,

--- a/src/context.ts
+++ b/src/context.ts
@@ -21,7 +21,6 @@ import {
     InternalCucumberOptions,
     InternalJiraOptions,
     InternalPluginOptions,
-    InternalSslOptions,
     InternalXrayOptions,
     Options,
     PluginContext,
@@ -29,7 +28,7 @@ import {
 import { dedent } from "./util/dedent";
 import { errorMessage } from "./util/errors";
 import { HELP } from "./util/help";
-import { asArrayOfStrings, asBoolean, asInt, asString, parse } from "./util/parsing";
+import { asArrayOfStrings, asBoolean, asString, parse } from "./util/parsing";
 import { pingJiraInstance, pingXrayCloud, pingXrayServer } from "./util/ping";
 
 let context: PluginContext | undefined = undefined;
@@ -262,25 +261,6 @@ export async function initCucumberOptions(
         };
     }
     return undefined;
-}
-
-/**
- * Returns an {@link InternalSslOptions | `InternalOpenSSLOptions`} instance based on parsed
- * environment variables and a provided options object. Environment variables will take precedence
- * over the options set in the object.
- *
- * @param env - an object containing environment variables as properties
- * @param options - an options object containing OpenSSL options
- * @returns the constructed internal OpenSSL options
- */
-export function initSslOptions(
-    env: Cypress.ObjectLike,
-    options: Options["openSSL"]
-): InternalSslOptions {
-    return {
-        ["rootCAPath"]: parse(env, ENV_NAMES.openSSL.rootCAPath, asString) ?? options?.rootCAPath,
-        secureOptions: parse(env, ENV_NAMES.openSSL.secureOptions, asInt) ?? options?.secureOptions,
-    };
 }
 
 export async function initClients(

--- a/src/conversion/importExecution/importExecutionConverter.spec.ts
+++ b/src/conversion/importExecution/importExecutionConverter.spec.ts
@@ -3,7 +3,7 @@ import chaiAsPromised from "chai-as-promised";
 import { readFileSync } from "fs";
 import { getMockedLogger } from "../../../test/mocks";
 import { expectToExist } from "../../../test/util";
-import { initJiraOptions, initPluginOptions, initSslOptions, initXrayOptions } from "../../context";
+import { initJiraOptions, initPluginOptions, initXrayOptions } from "../../context";
 import { Level } from "../../logging/logging";
 import { InternalOptions } from "../../types/plugin";
 import { dedent } from "../../util/dedent";
@@ -30,7 +30,6 @@ describe("the import execution converter", () => {
                 }
             ),
             plugin: initPluginOptions({}, {}),
-            ssl: initSslOptions({}, {}),
         };
         converter = new ImportExecutionConverter(options, false);
     });

--- a/src/conversion/importExecution/testConverter.spec.ts
+++ b/src/conversion/importExecution/testConverter.spec.ts
@@ -6,7 +6,6 @@ import {
     initCucumberOptions,
     initJiraOptions,
     initPluginOptions,
-    initSslOptions,
     initXrayOptions,
 } from "../../context";
 import { Level } from "../../logging/logging";
@@ -36,7 +35,6 @@ describe("the test converter", () => {
                 }
             ),
             plugin: initPluginOptions({}, {}),
-            ssl: initSslOptions({}, {}),
         };
     });
 

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -29,9 +29,9 @@ export async function importOptionalDependency<T>(packageName: string): Promise<
 /**
  * Dynamically imports a package.
  *
- * Note: This function is mainly used for stubbing purposes only, since `import` cannot be stubbed
+ * *Note: This function is mainly used for stubbing purposes only, since `import` cannot be stubbed
  * as it's not a function. You should probably use safer alternatives like
- * {@link importOptionalDependency | `importOptionalDependency`}.
+ * {@link importOptionalDependency | `importOptionalDependency`}.*
  *
  * @param packageName - the name of the package to import
  * @returns the package

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,7 +22,7 @@ interface Authentication {
 /**
  * Contains a mapping of all available options to their respective environment variable names.
  */
-export const ENV_NAMES: Remapping<Options & Authentication, string> = {
+export const ENV_NAMES: Remapping<Omit<Options, "http"> & Authentication, string> = {
     authentication: {
         jira: {
             username: "JIRA_USERNAME",
@@ -78,9 +78,5 @@ export const ENV_NAMES: Remapping<Options & Authentication, string> = {
             test: "CUCUMBER_PREFIXES_TEST",
         },
         uploadFeatures: "CUCUMBER_UPLOAD_FEATURES",
-    },
-    ["openSSL"]: {
-        ["rootCAPath"]: "OPENSSL_ROOT_CA_PATH",
-        secureOptions: "OPENSSL_SECURE_OPTIONS",
     },
 };

--- a/src/hooks/hooks.spec.ts
+++ b/src/hooks/hooks.spec.ts
@@ -10,7 +10,6 @@ import {
     initCucumberOptions,
     initJiraOptions,
     initPluginOptions,
-    initSslOptions,
     initXrayOptions,
 } from "../context";
 import { Level } from "../logging/logging";
@@ -44,7 +43,6 @@ describe("the hooks", () => {
                 }
             ),
             plugin: initPluginOptions({}, {}),
-            ssl: initSslOptions({}, {}),
         };
         const jiraClient = new JiraClientServer("https://example.org", new PatCredentials("token"));
         const xrayClient = new XrayClientServer("https://example.org", new PatCredentials("token"));

--- a/src/hooks/hooks.spec.ts
+++ b/src/hooks/hooks.spec.ts
@@ -2,7 +2,7 @@ import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { readFileSync } from "fs";
 import { stub } from "sinon";
-import { getMockedLogger } from "../../test/mocks";
+import { getMockedLogger, getMockedRestClient } from "../../test/mocks";
 import { PatCredentials } from "../authentication/credentials";
 import { JiraClientServer } from "../client/jira/jiraClientServer";
 import { XrayClientServer } from "../client/xray/xrayClientServer";
@@ -44,8 +44,16 @@ describe("the hooks", () => {
             ),
             plugin: initPluginOptions({}, {}),
         };
-        const jiraClient = new JiraClientServer("https://example.org", new PatCredentials("token"));
-        const xrayClient = new XrayClientServer("https://example.org", new PatCredentials("token"));
+        const jiraClient = new JiraClientServer(
+            "https://example.org",
+            new PatCredentials("token"),
+            getMockedRestClient()
+        );
+        const xrayClient = new XrayClientServer(
+            "https://example.org",
+            new PatCredentials("token"),
+            getMockedRestClient()
+        );
         const jiraFieldRepository = new CachingJiraFieldRepository(jiraClient);
         const jiraFieldFetcher = new CachingJiraIssueFetcher(
             jiraClient,

--- a/src/hooks/preprocessor/synchronizeFeatureFile.spec.ts
+++ b/src/hooks/preprocessor/synchronizeFeatureFile.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../test/mocks";
 import { JiraClient } from "../../client/jira/jiraClient";
 import { XrayClient } from "../../client/xray/xrayClient";
-import { initJiraOptions, initPluginOptions, initSslOptions, initXrayOptions } from "../../context";
+import { initJiraOptions, initPluginOptions, initXrayOptions } from "../../context";
 import { Level } from "../../logging/logging";
 import { SupportedFields } from "../../repository/jira/fields/jiraIssueFetcher";
 import { JiraRepository } from "../../repository/jira/jiraRepository";
@@ -40,7 +40,6 @@ describe("synchronizeFeatureFile", () => {
                 }
             ),
             plugin: initPluginOptions({}, {}),
-            ssl: initSslOptions({}, {}),
         };
         jiraClient = getMockedJiraClient();
         xrayClient = getMockedXrayClient();

--- a/src/https/requests.spec.ts
+++ b/src/https/requests.spec.ts
@@ -16,13 +16,6 @@ describe(path.relative(process.cwd(), __filename), () => {
     });
 
     describe("get", () => {
-        it("throws if init was not called", async () => {
-            const client = new AxiosRestClient();
-            await expect(client.get("https://example.org")).to.eventually.be.rejectedWith(
-                "Requests module has not been initialized"
-            );
-        });
-
         it("returns the response", async () => {
             const response: BaseAxios.AxiosResponse<string> = {
                 status: BaseAxios.HttpStatusCode.Ok,
@@ -33,9 +26,10 @@ describe(path.relative(process.cwd(), __filename), () => {
                     headers: new BaseAxios.AxiosHeaders(),
                 },
             };
-            stub(BaseAxios.default, "get").resolves(response);
+            const restClient = stub(BaseAxios.default.create());
+            stub(BaseAxios.default, "create").returns(restClient);
+            restClient.get.resolves(response);
             const client = new AxiosRestClient();
-            client.init({});
             expect(await client.get("https://example.org")).to.deep.contain(response);
         });
 
@@ -50,8 +44,7 @@ describe(path.relative(process.cwd(), __filename), () => {
             logger.logToFile.onSecondCall().returns("response.json");
             useFakeTimers(new Date(12345));
 
-            const client = new AxiosRestClient();
-            client.init({ debug: true });
+            const client = new AxiosRestClient({ debug: true });
             await expect(client.get("https://localhost:1234")).to.eventually.be.rejected;
             expect(logger.message).to.have.been.calledTwice;
             expect(logger.logToFile).to.have.been.calledWithMatch(
@@ -77,7 +70,6 @@ describe(path.relative(process.cwd(), __filename), () => {
         it("does not write to a file on encountering axios errors if debug is disabled", async () => {
             const logger = getMockedLogger();
             const client = new AxiosRestClient();
-            client.init({});
             await expect(client.get("https://localhost:1234")).to.eventually.be.rejected;
             expect(logger.message).to.not.have.been.called;
             expect(logger.logToFile).to.not.have.been.called;
@@ -85,16 +77,8 @@ describe(path.relative(process.cwd(), __filename), () => {
     });
 
     describe("post", () => {
-        it("throws if init was not called", async () => {
-            const client = new AxiosRestClient();
-            await expect(client.post("https://example.org")).to.eventually.be.rejectedWith(
-                "Requests module has not been initialized"
-            );
-        });
-
         it("returns the response", async () => {
             const client = new AxiosRestClient();
-            client.init({});
             const response: BaseAxios.AxiosResponse<string> = {
                 status: BaseAxios.HttpStatusCode.Ok,
                 data: "Example domain 123",
@@ -104,7 +88,9 @@ describe(path.relative(process.cwd(), __filename), () => {
                     headers: new BaseAxios.AxiosHeaders(),
                 },
             };
-            stub(BaseAxios.default, "post").resolves(response);
+            const restClient = stub(BaseAxios.default.create());
+            stub(BaseAxios.default, "create").returns(restClient);
+            restClient.post.resolves(response);
             expect(await client.post("https://example.org")).to.deep.eq(response);
         });
 
@@ -119,8 +105,7 @@ describe(path.relative(process.cwd(), __filename), () => {
             logger.logToFile.onSecondCall().returns("response.json");
             useFakeTimers(new Date(12345));
 
-            const client = new AxiosRestClient();
-            client.init({ debug: true });
+            const client = new AxiosRestClient({ debug: true });
             await expect(
                 client.post("https://localhost:1234", {
                     hello: "!",
@@ -158,7 +143,6 @@ describe(path.relative(process.cwd(), __filename), () => {
         it("does not write to a file on encountering axios errors if debug is disabled", async () => {
             const logger = getMockedLogger();
             const client = new AxiosRestClient();
-            client.init({});
             await expect(client.get("https://localhost:1234")).to.eventually.be.rejected;
             expect(logger.message).to.not.have.been.called;
             expect(logger.logToFile).to.not.have.been.called;
@@ -166,16 +150,8 @@ describe(path.relative(process.cwd(), __filename), () => {
     });
 
     describe("put", () => {
-        it("throws if init was not called", async () => {
-            const client = new AxiosRestClient();
-            await expect(client.put("https://example.org")).to.eventually.be.rejectedWith(
-                "Requests module has not been initialized"
-            );
-        });
-
         it("returns the response", async () => {
             const client = new AxiosRestClient();
-            client.init({});
             const response: BaseAxios.AxiosResponse<string> = {
                 status: BaseAxios.HttpStatusCode.Ok,
                 data: "Example domain 123",
@@ -185,7 +161,9 @@ describe(path.relative(process.cwd(), __filename), () => {
                     headers: new BaseAxios.AxiosHeaders(),
                 },
             };
-            stub(BaseAxios.default, "put").resolves(response);
+            const restClient = stub(BaseAxios.default.create());
+            stub(BaseAxios.default, "create").returns(restClient);
+            restClient.put.resolves(response);
             expect(await client.put("https://example.org")).to.deep.eq(response);
         });
 
@@ -200,8 +178,7 @@ describe(path.relative(process.cwd(), __filename), () => {
             logger.logToFile.onSecondCall().returns("response.json");
             useFakeTimers(new Date(12345));
 
-            const client = new AxiosRestClient();
-            client.init({ debug: true });
+            const client = new AxiosRestClient({ debug: true });
             await expect(
                 client.put("https://localhost:1234", {
                     hello: "!",
@@ -239,7 +216,6 @@ describe(path.relative(process.cwd(), __filename), () => {
         it("does not write to a file on encountering axios errors if debug is disabled", async () => {
             const logger = getMockedLogger();
             const client = new AxiosRestClient();
-            client.init({});
             await expect(client.get("https://localhost:1234")).to.eventually.be.rejected;
             expect(logger.message).to.not.have.been.called;
             expect(logger.logToFile).to.not.have.been.called;

--- a/src/https/requests.ts
+++ b/src/https/requests.ts
@@ -1,10 +1,10 @@
 import axios, {
+    AxiosInstance,
     AxiosRequestConfig,
     AxiosResponse,
     InternalAxiosRequestConfig,
     isAxiosError,
 } from "axios";
-import { readFileSync } from "fs";
 import { LOG, Level } from "../logging/logging";
 import { normalizedFilename } from "../util/files";
 import { unknownToString } from "../util/string";
@@ -30,11 +30,11 @@ export interface RequestsOptions {
 }
 
 export class AxiosRestClient {
-    private axios: typeof axios | undefined = undefined;
+    private readonly options: RequestsOptions | undefined;
 
-    private options: RequestsOptions | undefined = undefined;
+    private axios: AxiosInstance | undefined = undefined;
 
-    public init(options: RequestsOptions): void {
+    constructor(options?: RequestsOptions) {
         this.options = options;
     }
 
@@ -70,13 +70,10 @@ export class AxiosRestClient {
         });
     }
 
-    private getAxios(): typeof axios {
-        if (!this.options) {
-            throw new Error("Requests module has not been initialized");
-        }
+    private getAxios(): AxiosInstance {
         if (!this.axios) {
-            this.axios = axios;
-            if (this.options.debug) {
+            this.axios = axios.create();
+            if (this.options?.debug) {
                 this.axios.interceptors.request.use(
                     (request: InternalAxiosRequestConfig<unknown>) => {
                         const method = request.method?.toUpperCase();
@@ -178,13 +175,4 @@ export class AxiosRestClient {
         }
         return this.axios;
     }
-
-    private readCertificate(path?: string): Buffer | undefined {
-        if (!path) {
-            return undefined;
-        }
-        return readFileSync(path);
-    }
 }
-
-export const REST: AxiosRestClient = new AxiosRestClient();

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import fs from "fs";
+import { Agent } from "https";
 import { stub } from "sinon";
 import { getMockedLogger, getMockedRestClient } from "../test/mocks";
 import { mockedCypressEventEmitter } from "../test/util";
@@ -47,7 +48,6 @@ describe("the plugin", () => {
                 jira: jiraOptions,
                 plugin: context.initPluginOptions({}, {}),
                 xray: context.initXrayOptions({}, {}),
-                ssl: context.initSslOptions({}, {}),
             },
             clients: {
                 kind: "server",
@@ -128,9 +128,11 @@ describe("the plugin", () => {
                     downloadFeatures: false,
                     uploadFeatures: false,
                 },
-                ["openSSL"]: {
-                    ["rootCAPath"]: "/home/somewhere",
-                    secureOptions: 42,
+                http: {
+                    httpAgent: new Agent({
+                        ca: "/home/somewhere",
+                        secureOptions: 42,
+                    }),
                 },
             };
             await configureXrayPlugin(config, options);
@@ -171,7 +173,7 @@ describe("the plugin", () => {
                 enabled: true,
                 output: "somewhere",
             });
-            expect(stubbedContext.firstCall.args[0].internal.ssl).to.deep.eq(options.openSSL);
+            expect(stubbedContext.firstCall.args[0].internal.http).to.deep.eq(options.http);
             expect(stubbedContext.firstCall.args[0].clients).to.eq(pluginContext.clients);
         });
 
@@ -188,7 +190,7 @@ describe("the plugin", () => {
             await configureXrayPlugin(config, options);
             expect(restClient.init).to.have.been.calledOnceWithExactly({
                 debug: false,
-                ssl: pluginContext.internal.ssl,
+                http: pluginContext.internal.http,
             });
         });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,6 +3,7 @@ import {
     getPluginContext,
     initClients,
     initCucumberOptions,
+    initHttpClients,
     initJiraOptions,
     initPluginOptions,
     initXrayOptions,
@@ -10,7 +11,6 @@ import {
 } from "./context";
 import { afterRunHook, beforeRunHook } from "./hooks/hooks";
 import { synchronizeFeatureFile } from "./hooks/preprocessor/synchronizeFeatureFile";
-import { REST } from "./https/requests";
 import { LOG, Level } from "./logging/logging";
 import { InternalOptions, InternalPluginOptions, Options } from "./types/plugin";
 import { dedent } from "./util/dedent";
@@ -65,14 +65,17 @@ export async function configureXrayPlugin(
         cucumber: await initCucumberOptions(config, options.cucumber),
         http: options.http,
     };
-    REST.init({
-        debug: internalOptions.plugin.debug,
-        http: options.http,
-    });
+    const httpClients = initHttpClients(
+        {
+            debug: internalOptions.plugin.debug,
+        },
+        internalOptions.http
+    );
+    const clients = await initClients(internalOptions.jira, config.env, httpClients);
     setPluginContext({
         cypress: config,
         internal: internalOptions,
-        clients: await initClients(internalOptions.jira, config.env),
+        clients: clients,
     });
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -126,7 +126,7 @@ export async function configureXrayPlugin(
 /**
  * Attempts to synchronize the Cucumber feature file with Xray. If the filename does not end with
  * the configured {@link https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/cucumber/#featurefileextension | feature file extension},
- * this method does not upload anything to Xray.
+ * this method will not upload anything to Xray.
  *
  * @param file - the Cypress file object
  * @returns the unmodified file's path

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,7 +5,6 @@ import {
     initCucumberOptions,
     initJiraOptions,
     initPluginOptions,
-    initSslOptions,
     initXrayOptions,
     setPluginContext,
 } from "./context";
@@ -64,11 +63,11 @@ export async function configureXrayPlugin(
         plugin: pluginOptions,
         xray: initXrayOptions(config.env, options.xray),
         cucumber: await initCucumberOptions(config, options.cucumber),
-        ssl: initSslOptions(config.env, options.openSSL),
+        http: options.http,
     };
     REST.init({
         debug: internalOptions.plugin.debug,
-        ssl: internalOptions.ssl,
+        http: options.http,
     });
     setPluginContext({
         cypress: config,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,11 +27,13 @@ export function resetPlugin(): void {
 }
 
 /**
- * Configures the plugin. The plugin will inspect all environment variables passed in
- * {@link Cypress.PluginConfigOptions.env | `config.env`} and merge them with the ones provided in
- * `options`. Environment variables always take precedence over values specified in `options`.
+ * Configures the plugin. The plugin will check all environment variables passed in
+ * {@link Cypress.PluginConfigOptions.env | `config.env`} and merge them with those specified in
+ * `options`. Environment variables always override values specified in `options`.
  *
- * Note: This method will register several upload hooks under the passed plugin events.
+ * *Note: This method will register upload hooks under the Cypress `before:run` and `after:run`
+ * events. Consider using [`cypress-on-fix`](https://github.com/bahmutov/cypress-on-fix) if you
+ * have other hooks registered to prevent the plugin from replacing them.*
  *
  * @param on - the Cypress plugin events
  * @param config - the Cypress configuration

--- a/src/repository/jira/fields/jiraFieldRepository.spec.ts
+++ b/src/repository/jira/fields/jiraFieldRepository.spec.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { stub } from "sinon";
+import { getMockedRestClient } from "../../../../test/mocks";
 import { BasicAuthCredentials } from "../../../authentication/credentials";
 import { JiraClientServer } from "../../../client/jira/jiraClientServer";
 import { dedent } from "../../../util/dedent";
@@ -16,7 +17,8 @@ describe("the jira field repository", () => {
     beforeEach(() => {
         jiraClient = new JiraClientServer(
             "https://example.org",
-            new BasicAuthCredentials("user", "xyz")
+            new BasicAuthCredentials("user", "xyz"),
+            getMockedRestClient()
         );
         repository = new CachingJiraFieldRepository(jiraClient);
     });

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -333,6 +333,30 @@ export type InternalCucumberOptions = Required<CucumberOptions> & {
     preprocessor?: IPreprocessorConfiguration;
 };
 
+/**
+ * HTTP configuration to use for requests the plugin makes. You can define default options to use
+ * for all requests and override them with individual options for Jira or Xray:
+ *
+ * ```ts
+ * {
+ *   // ...other plugin options
+ *   http: {
+ *     timeout: 5000,
+ *     jira: {
+ *       proxy: {
+ *         host: "http://1.2.3.4",
+ *         port: 12345
+ *       }
+ *     },
+ *     xray: {
+ *       timeout: 10000,
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @see https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/http
+ */
 export type HttpOptions = AxiosRequestConfig & {
     /**
      * The HTTP configuration for requests directed at Jira. HTTP options defined for both clients

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -7,10 +7,57 @@ import { JiraRepository } from "../repository/jira/jiraRepository";
 import { IssueTypeDetails } from "./jira/responses/issueTypeDetails";
 
 export interface Options {
+    /**
+     * Defines Jira-specific options that control how the plugin interacts with Jira.
+     *
+     * @see https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/jira/
+     */
     jira: JiraOptions;
+    /**
+     * Options for configuring the general behaviour of the plugin.
+     *
+     * @see https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/plugin/
+     */
     plugin?: PluginOptions;
+    /**
+     * Xray settings that may be required depending on your project configuration.
+     *
+     * @see https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/xray/
+     */
     xray?: XrayOptions;
+    /**
+     * When Cucumber is enabled, you can use these options to configure how the plugin works with
+     * your feature files.
+     *
+     * @see https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/cucumber/
+     */
     cucumber?: CucumberOptions;
+    /**
+     * HTTP configuration to be used for requests made by the plugin. You can set default options to be
+     * used for all requests and override them with individual options for Jira or Xray.
+     *
+     * @example
+     *
+     * ```ts
+     * {
+     *   // ...other plugin options
+     *   http: {
+     *     timeout: 5000,
+     *     jira: {
+     *       proxy: {
+     *         host: "http://1.2.3.4",
+     *         port: 12345
+     *       }
+     *     },
+     *     xray: {
+     *       timeout: 10000,
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * @see https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/http
+     */
     http?: HttpOptions;
 }
 
@@ -51,6 +98,9 @@ export interface JiraFieldIds {
     testType?: string;
 }
 
+/**
+ * Jira-specific options that control how the plugin interacts with Jira.
+ */
 export interface JiraOptions {
     /**
      * The Jira project key.
@@ -170,6 +220,9 @@ export type InternalJiraOptions = JiraOptions &
         testExecutionIssueDetails: IssueTypeDetails;
     };
 
+/**
+ * Xray settings that may be required depending on the project configuration.
+ */
 export interface XrayOptions {
     /**
      * A mapping of Cypress statuses to corresponding Xray statuses.
@@ -237,6 +290,10 @@ export interface XrayOptions {
 export type InternalXrayOptions = XrayOptions &
     Required<Pick<XrayOptions, "status" | "uploadResults" | "uploadScreenshots">>;
 
+/**
+ * When Cucumber is enabled, these options are used to configure how the plugin works with
+ * encountered feature files.
+ */
 export interface CucumberOptions {
     /**
      * The file extension of feature files you want to run in Cypress. The plugin will use this to
@@ -326,45 +383,26 @@ export interface CucumberOptions {
  * A more specific Cucumber options type with optional properties converted to required ones if
  * default/fallback values are used by the plugin.
  */
-export type InternalCucumberOptions = Required<CucumberOptions> & {
+export interface InternalCucumberOptions extends Required<CucumberOptions> {
     /**
      * The Cucumber preprocessor configuration.
      */
     preprocessor?: IPreprocessorConfiguration;
-};
+}
 
 /**
- * HTTP configuration to use for requests the plugin makes. You can define default options to use
- * for all requests and override them with individual options for Jira or Xray:
- *
- * ```ts
- * {
- *   // ...other plugin options
- *   http: {
- *     timeout: 5000,
- *     jira: {
- *       proxy: {
- *         host: "http://1.2.3.4",
- *         port: 12345
- *       }
- *     },
- *     xray: {
- *       timeout: 10000,
- *     }
- *   }
- * }
- * ```
- *
- * @see https://qytera-gmbh.github.io/projects/cypress-xray-plugin/section/configuration/http
+ * Options which the plugin will use when making HTTP requests. You can specify
+ * [common options](https://axios-http.com/docs/req_config) to use for all requests or choose to
+ * define specific ones for Jira or Xray.
  */
-export type HttpOptions = AxiosRequestConfig & {
+export interface HttpOptions extends AxiosRequestConfig {
     /**
-     * The HTTP configuration for requests directed at Jira. HTTP options defined for both clients
-     * will be overriden in the Jira client by the ones defined here.
+     * The HTTP configuration for requests to Jira. HTTP options defined for both clients will be
+     * overridden in the Jira client by those defined here.
      *
-     * Note: when in a Jira/Xray server environment, Jira and Xray endpoints will be located
-     * at the same host. To avoid duplicating your HTTP configuration, it is recommended to
-     * define a single one instead, e.g.:
+     * *Note: In a Jira/Xray server environment, the Jira and Xray endpoints will reside on the same
+     * host. To avoid duplicating your HTTP configuration, it is recommended that you define a
+     * single one instead, e.g.:*
      *
      * ```ts
      * {
@@ -380,12 +418,12 @@ export type HttpOptions = AxiosRequestConfig & {
      */
     jira?: AxiosRequestConfig;
     /**
-     * The HTTP configuration for requests directed at Xray. HTTP options defined for both clients
-     * will be overriden in the Xray client by the ones defined here.
+     * The HTTP configuration for requests to Xray. HTTP options defined for both clients will be
+     * overridden in the Jira client by those defined here.
      *
-     * Note: when in a Jira/Xray server environment, Jira and Xray endpoints will be located
-     * at the same host. To avoid duplicating your HTTP configuration, it is recommended to
-     * define a single one instead, e.g.:
+     * *Note: In a Jira/Xray server environment, the Jira and Xray endpoints will reside on the same
+     * host. To avoid duplicating your HTTP configuration, it is recommended that you define a
+     * single one instead, e.g.:*
      *
      * ```ts
      * {
@@ -400,18 +438,21 @@ export type HttpOptions = AxiosRequestConfig & {
      * ```
      */
     xray?: AxiosRequestConfig;
-};
+}
 
 export type InternalHttpOptions = HttpOptions;
 
+/**
+ * Options for configuring the general behaviour of the plugin.
+ */
 export interface PluginOptions {
     /**
-     * Enables or disables the entire plugin. Setting this option to `false` disables all plugin
-     * functions, including authentication checks, uploads or feature file synchronization.
+     * Enables or disables the entire plugin. Setting this option to false will disable all plugin
+     * functions, including authentication checks, uploads or feature file synchronisation.
      */
     enabled?: boolean;
     /**
-     * Turns on or off extensive debugging output.
+     * Enables or disables extensive debugging output.
      */
     debug?: boolean;
     /**
@@ -419,9 +460,9 @@ export interface PluginOptions {
      */
     logDirectory?: string;
     /**
-     * Some Xray setups might struggle with uploaded evidence if the filenames contain non-ASCII
-     * characters. With this option enabled, the plugin only allows characters `a-zA-Z0-9.` in
-     * screenshot names and replaces all other sequences with `_`.
+     * Some Xray setups may have problems with uploaded evidence if the filenames contain non-ASCII
+     * characters. With this option enabled, the plugin will only allow the characters `a-zA-Z0-9.`
+     * in screenshot names, and will replace all other sequences with `_`.
      */
     normalizeScreenshotNames?: boolean;
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -333,18 +333,50 @@ export type InternalCucumberOptions = Required<CucumberOptions> & {
     preprocessor?: IPreprocessorConfiguration;
 };
 
-export type HttpOptions =
-    | AxiosRequestConfig
-    | {
-          /**
-           * The HTTP configuration for requests directed at Jira.
-           */
-          jira?: AxiosRequestConfig;
-          /**
-           * The HTTP configuration for requests directed at Xray.
-           */
-          xray?: AxiosRequestConfig;
-      };
+export type HttpOptions = AxiosRequestConfig & {
+    /**
+     * The HTTP configuration for requests directed at Jira. HTTP options defined for both clients
+     * will be overriden in the Jira client by the ones defined here.
+     *
+     * Note: when in a Jira/Xray server environment, Jira and Xray endpoints will be located
+     * at the same host. To avoid duplicating your HTTP configuration, it is recommended to
+     * define a single one instead, e.g.:
+     *
+     * ```ts
+     * {
+     *   // ...other plugin options
+     *   http: {
+     *     proxy: {
+     *       host: "http://1.2.3.4",
+     *       port: 12345
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    jira?: AxiosRequestConfig;
+    /**
+     * The HTTP configuration for requests directed at Xray. HTTP options defined for both clients
+     * will be overriden in the Xray client by the ones defined here.
+     *
+     * Note: when in a Jira/Xray server environment, Jira and Xray endpoints will be located
+     * at the same host. To avoid duplicating your HTTP configuration, it is recommended to
+     * define a single one instead, e.g.:
+     *
+     * ```ts
+     * {
+     *   // ...other plugin options
+     *   http: {
+     *     proxy: {
+     *       host: "http://1.2.3.4",
+     *       port: 12345
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    xray?: AxiosRequestConfig;
+};
 
 export type InternalHttpOptions = HttpOptions;
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,4 +1,5 @@
 import { IPreprocessorConfiguration } from "@badeball/cypress-cucumber-preprocessor";
+import { AxiosRequestConfig } from "axios";
 import { JiraClient } from "../client/jira/jiraClient";
 import { XrayClient } from "../client/xray/xrayClient";
 import { JiraRepository } from "../repository/jira/jiraRepository";
@@ -9,7 +10,7 @@ export interface Options {
     plugin?: PluginOptions;
     xray?: XrayOptions;
     cucumber?: CucumberOptions;
-    ["openSSL"]?: OpenSSLOptions;
+    http?: AxiosRequestConfig;
 }
 
 export interface JiraFieldIds {
@@ -362,42 +363,6 @@ export type InternalPluginOptions = PluginOptions &
         Pick<PluginOptions, "debug" | "enabled" | "logDirectory" | "normalizeScreenshotNames">
     >;
 
-/* eslint-disable @typescript-eslint/naming-convention */
-export interface OpenSSLOptions {
-    /**
-     * Specify the path to a root CA in .pem format. This will then be used to authenticate against
-     * the Xray instance.
-     */
-    rootCAPath?: string;
-    /**
-     * A {@link https://nodejs.org/api/crypto.html#crypto-constants | crypto constant} that will be
-     * used to configure the `securityOptions` of the
-     * {@link https://nodejs.org/api/https.html#class-httpsagent | https.Agent} used for sending
-     * requests to your Xray instance.
-     *
-     * *Note: Compute their bitwise OR if you need to set more than one option.*
-     *
-     * @example
-     * ```ts
-     * import { constants } from "crypto";
-     * // ...
-     *   openSSL: {
-     *     secureOptions: constants.SSL_OP_LEGACY_SERVER_CONNECT |
-     *                    constants.SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION
-     *   }
-     * // ...
-     * ```
-     */
-    secureOptions?: number;
-}
-/* eslint-enable @typescript-eslint/naming-convention */
-
-/**
- * A more specific OpenSSL options type with optional properties converted to required ones if
- * default/fallback values are used by the plugin.
- */
-export type InternalSslOptions = OpenSSLOptions;
-
 /**
  * Options only intended for internal plugin use.
  */
@@ -406,7 +371,7 @@ export interface InternalOptions {
     plugin: InternalPluginOptions;
     xray: InternalXrayOptions;
     cucumber?: InternalCucumberOptions;
-    ssl: InternalSslOptions;
+    http?: AxiosRequestConfig;
 }
 
 /**

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -448,7 +448,7 @@ export type InternalHttpOptions = HttpOptions;
 export interface PluginOptions {
     /**
      * Enables or disables the entire plugin. Setting this option to false will disable all plugin
-     * functions, including authentication checks, uploads or feature file synchronisation.
+     * functions, including authentication checks, uploads or feature file synchronization.
      */
     enabled?: boolean;
     /**

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -2,6 +2,7 @@ import { IPreprocessorConfiguration } from "@badeball/cypress-cucumber-preproces
 import { AxiosRequestConfig } from "axios";
 import { JiraClient } from "../client/jira/jiraClient";
 import { XrayClient } from "../client/xray/xrayClient";
+import { AxiosRestClient } from "../https/requests";
 import { JiraRepository } from "../repository/jira/jiraRepository";
 import { IssueTypeDetails } from "./jira/responses/issueTypeDetails";
 
@@ -10,7 +11,7 @@ export interface Options {
     plugin?: PluginOptions;
     xray?: XrayOptions;
     cucumber?: CucumberOptions;
-    http?: AxiosRequestConfig;
+    http?: HttpOptions;
 }
 
 export interface JiraFieldIds {
@@ -332,6 +333,21 @@ export type InternalCucumberOptions = Required<CucumberOptions> & {
     preprocessor?: IPreprocessorConfiguration;
 };
 
+export type HttpOptions =
+    | AxiosRequestConfig
+    | {
+          /**
+           * The HTTP configuration for requests directed at Jira.
+           */
+          jira?: AxiosRequestConfig;
+          /**
+           * The HTTP configuration for requests directed at Xray.
+           */
+          xray?: AxiosRequestConfig;
+      };
+
+export type InternalHttpOptions = HttpOptions;
+
 export interface PluginOptions {
     /**
      * Enables or disables the entire plugin. Setting this option to `false` disables all plugin
@@ -371,7 +387,7 @@ export interface InternalOptions {
     plugin: InternalPluginOptions;
     xray: InternalXrayOptions;
     cucumber?: InternalCucumberOptions;
-    http?: AxiosRequestConfig;
+    http?: InternalHttpOptions;
 }
 
 /**
@@ -382,6 +398,14 @@ export interface ClientCombination {
     jiraClient: JiraClient;
     xrayClient: XrayClient;
     jiraRepository: JiraRepository;
+}
+
+/**
+ * Wraps the REST clients used for HTTP requests directed at Jira and Xray.
+ */
+export interface HttpClientCombination {
+    jira: AxiosRestClient;
+    xray: AxiosRestClient;
 }
 
 export interface PluginContext {

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -208,7 +208,6 @@ export function missingTestKeyInCucumberScenarioError(
  * @param tags - the scenario tags
  * @param issueKeys - the issue keys
  * @param isCloudClient - whether Xray cloud is being used
- * @param testPrefix - the prefix of issues linked in scenario tags
  * @returns the error
  */
 export function multipleTestKeysInCucumberScenarioError(

--- a/src/util/extraction.ts
+++ b/src/util/extraction.ts
@@ -56,7 +56,7 @@ export function extractArrayOfStrings(data: unknown, propertyName: string): stri
  * ```
  *
  * @param data - the object
- * @param propertyName - the property to access
+ * @param propertyNames - the properties to access
  * @returns the property's string value
  * @throws if `data` is not an object or does not contain a nested string property `propertyName`
  */

--- a/src/util/ping.spec.ts
+++ b/src/util/ping.spec.ts
@@ -33,7 +33,7 @@ describe("Jira instance ping", () => {
                 statusText: HttpStatusCode[HttpStatusCode.Ok],
                 config: { headers: new AxiosHeaders() },
             });
-        await pingJiraInstance("https://example.org", new PatCredentials("token"));
+        await pingJiraInstance("https://example.org", new PatCredentials("token"), restClient);
     });
 
     it("returns false if no license data is returned", async () => {
@@ -45,7 +45,7 @@ describe("Jira instance ping", () => {
             config: { headers: new AxiosHeaders() },
         });
         await expect(
-            pingJiraInstance("https://example.org", new PatCredentials("token"))
+            pingJiraInstance("https://example.org", new PatCredentials("token"), restClient)
         ).to.eventually.be.rejectedWith(
             dedent(`
                 Failed to establish communication with Jira: https://example.org
@@ -72,7 +72,7 @@ describe("Jira instance ping", () => {
             config: { headers: new AxiosHeaders() },
         });
         await expect(
-            pingJiraInstance("https://example.org", new PatCredentials("token"))
+            pingJiraInstance("https://example.org", new PatCredentials("token"), restClient)
         ).to.eventually.be.rejectedWith(
             dedent(`
                 Failed to establish communication with Jira: https://example.org
@@ -120,7 +120,11 @@ describe("Jira instance ping", () => {
             )
             .onFirstCall()
             .returns();
-        const promise = pingJiraInstance("https://example.org", new PatCredentials("token"));
+        const promise = pingJiraInstance(
+            "https://example.org",
+            new PatCredentials("token"),
+            restClient
+        );
         clock.tick(10000);
         await promise;
     });
@@ -147,7 +151,7 @@ describe("Xray server ping", () => {
                 statusText: HttpStatusCode[HttpStatusCode.Ok],
                 config: { headers: new AxiosHeaders() },
             });
-        await pingXrayServer("https://example.org", new PatCredentials("token"));
+        await pingXrayServer("https://example.org", new PatCredentials("token"), restClient);
     });
 
     it("returns false if no license data is returned", async () => {
@@ -159,7 +163,7 @@ describe("Xray server ping", () => {
             config: { headers: new AxiosHeaders() },
         });
         await expect(
-            pingXrayServer("https://example.org", new PatCredentials("token"))
+            pingXrayServer("https://example.org", new PatCredentials("token"), restClient)
         ).to.eventually.be.rejectedWith(
             dedent(`
                 Failed to establish communication with Xray: https://example.org
@@ -188,7 +192,7 @@ describe("Xray server ping", () => {
             config: { headers: new AxiosHeaders() },
         });
         await expect(
-            pingXrayServer("https://example.org", new PatCredentials("token"))
+            pingXrayServer("https://example.org", new PatCredentials("token"), restClient)
         ).to.eventually.be.rejectedWith(
             dedent(`
                 Failed to establish communication with Xray: https://example.org
@@ -240,7 +244,11 @@ describe("Xray server ping", () => {
             )
             .onFirstCall()
             .returns();
-        const promise = pingXrayServer("https://example.org", new PatCredentials("token"));
+        const promise = pingXrayServer(
+            "https://example.org",
+            new PatCredentials("token"),
+            restClient
+        );
         clock.tick(10000);
         await promise;
     });
@@ -280,7 +288,7 @@ describe("Xray cloud ping", () => {
             config: { headers: new AxiosHeaders() },
         });
         await expect(
-            pingXrayCloud(new JwtCredentials("id", "secret", "https://example.org"))
+            pingXrayCloud(new JwtCredentials("id", "secret", "https://example.org", restClient))
         ).to.eventually.be.rejectedWith(
             dedent(`
                 Failed to establish communication with Xray: https://example.org

--- a/src/util/ping.ts
+++ b/src/util/ping.ts
@@ -4,7 +4,7 @@ import {
     JwtCredentials,
     PatCredentials,
 } from "../authentication/credentials";
-import { REST } from "../https/requests";
+import { AxiosRestClient } from "../https/requests";
 import { LOG, Level } from "../logging/logging";
 import { User } from "../types/jira/responses/user";
 import { XrayLicenseStatus } from "../types/xray/responses/license";
@@ -20,12 +20,14 @@ import { startInterval } from "./time";
  *
  * @param url - the base URL of the Jira instance
  * @param credentials - the credentials of a valid Jira user
+ * @param httpClient - the HTTP client to use to dispatch the ping
  * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-myself-get
  * @see https://docs.atlassian.com/software/jira/docs/api/REST/9.11.0/#api/2/myself
  */
 export async function pingJiraInstance(
     url: string,
-    credentials: BasicAuthCredentials | PatCredentials
+    credentials: BasicAuthCredentials | PatCredentials,
+    httpClient: AxiosRestClient
 ): Promise<void> {
     LOG.message(Level.DEBUG, "Pinging Jira instance...");
     const progressInterval = startInterval((totalTime: number) => {
@@ -36,11 +38,14 @@ export async function pingJiraInstance(
     });
     try {
         const header = credentials.getAuthorizationHeader();
-        const userResponse: AxiosResponse<User> = await REST.get(`${url}/rest/api/latest/myself`, {
-            headers: {
-                ...header,
-            },
-        });
+        const userResponse: AxiosResponse<User> = await httpClient.get(
+            `${url}/rest/api/latest/myself`,
+            {
+                headers: {
+                    ...header,
+                },
+            }
+        );
         const username = getUserString(userResponse.data);
         if (username) {
             LOG.message(
@@ -89,11 +94,13 @@ function getUserString(user: User): string | undefined {
  *
  * @param url - the base URL of the Xray server instance
  * @param credentials - the credentials of a user with a valid Xray license
+ * @param httpClient - the HTTP client to use to dispatch the ping
  * @see https://docs.getxray.app/display/XRAY/v2.0#/External%20Apps/get_xraylicense
  */
 export async function pingXrayServer(
     url: string,
-    credentials: BasicAuthCredentials | PatCredentials
+    credentials: BasicAuthCredentials | PatCredentials,
+    httpClient: AxiosRestClient
 ): Promise<void> {
     LOG.message(Level.DEBUG, "Pinging Xray server instance...");
     const progressInterval = startInterval((totalTime: number) => {
@@ -104,7 +111,7 @@ export async function pingXrayServer(
     });
     try {
         const header = credentials.getAuthorizationHeader();
-        const licenseResponse: AxiosResponse<XrayLicenseStatus> = await REST.get(
+        const licenseResponse: AxiosResponse<XrayLicenseStatus> = await httpClient.get(
             `${url}/rest/raven/latest/api/xraylicense`,
             {
                 headers: {

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -6,7 +6,7 @@ import { JwtCredentials } from "../src/authentication/credentials";
 import { JiraClient } from "../src/client/jira/jiraClient";
 import { XrayClient } from "../src/client/xray/xrayClient";
 import { HasTestTypes, XrayClientCloud } from "../src/client/xray/xrayClientCloud";
-import { AxiosRestClient, REST } from "../src/https/requests";
+import { AxiosRestClient } from "../src/https/requests";
 import * as logging from "../src/logging/logging";
 import { Logger } from "../src/logging/logging";
 import { JiraFieldRepository } from "../src/repository/jira/fields/jiraFieldRepository";
@@ -47,7 +47,7 @@ export function getMockedLogger(
 }
 
 export function getMockedRestClient(): SinonStubbedInstance<AxiosRestClient> {
-    const client = stub(REST);
+    const client = stub(new AxiosRestClient({}));
     client.get.callsFake((url: string, config?: AxiosRequestConfig<unknown>) => {
         throw mockCalledUnexpectedlyError(url, config);
     });
@@ -191,7 +191,9 @@ export function getMockedJiraRepository(): SinonStubbedInstance<JiraRepository> 
 }
 
 export function getMockedJwtCredentials(): SinonStubbedInstance<JwtCredentials> {
-    return makeTransparent(stub(new JwtCredentials("abc", "xyz", "https://example.org")));
+    return makeTransparent(
+        stub(new JwtCredentials("abc", "xyz", "https://example.org", getMockedRestClient()))
+    );
 }
 
 function mockCalledUnexpectedlyError(...args: unknown[]): Error {


### PR DESCRIPTION
## Breaking changes:
- removed `openSSL` option
- removed `OPENSSL_ROOT_CA_PATH` environment variable
- removed `OPENSSL_SECURE_OPTIONS` environment variable

## New features:
- added `http` option
  - root CA path and secure options can now be set as follows:
 
    ```ts
    import { Agent } from "node:https";
    import { constants } from "node:crypto";
    // ...

    {
      jira: {
        projectKey: "ABC",
        url: "https://example.org",
      },
      http: {
        httpAgent: new Agent({
          ca: "/home/somewhere/ca.pem",
          secureOptions: constants.SSL_OP_LEGACY_SERVER_CONNECT | constants.SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION,
        }),
      }
    }
    ```
  
  - also allows for proxy configuration:
 
    ```ts
    import { Agent } from "node:https";
    // ...

    {
      jira: {
        projectKey: "ABC",
        url: "https://example.org",
      },
      http: {
        proxy: {
          host: "https://example.org",
          port: 1234,
          auth: {
            username: 'john',
            password: 'supersecret'
          }
        }
      }
    }
    ```
  
  - also allows for separate proxy configuration:
 
    ```ts
    import { Agent } from "node:https";
    // ...

    {
      jira: {
        projectKey: "ABC",
        url: "https://example.org",
      },
      // only jira or only xray configuration are also possible, no need to define both
      http: {
        jira: {
          proxy: {
            host: "https://example.org",
            port: 1234,
            auth: {
              username: 'john in jira',
              password: 'supersecret'
            }
          }
        },
        xray: {
          proxy: {
            host: "http://1.2.3.4",
            port: 1234,
            auth: {
              username: 'john but xray now',
              password: 'supersecret'
            }
          }
        }
      }
    }
    ```