### PR TITLE
Explicitly take project root into account

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import {
     PluginContext,
     getPluginContext,
@@ -67,6 +68,11 @@ export async function configureXrayPlugin(
     }
     // Init logging before all other configurations because they might require an initialized
     // logging module.
+    if (!path.isAbsolute(pluginOptions.logDirectory)) {
+        // Cypress might change process.cwd(), so we need to query the root directory.
+        // See: https://github.com/cypress-io/cypress/issues/22689
+        pluginOptions.logDirectory = path.resolve(config.projectRoot, pluginOptions.logDirectory);
+    }
     LOG.configure({
         debug: pluginOptions.debug,
         logDirectory: pluginOptions.logDirectory,
@@ -140,7 +146,10 @@ export async function configureXrayPlugin(
                 }
                 await afterRunHook(
                     results as CypressCommandLine.CypressRunResult,
-                    context.getOptions(),
+                    {
+                        ...context.getOptions(),
+                        cypress: config,
+                    },
                     context.getClients(),
                     context
                 );

--- a/src/types/cypress/12.0.0/cypress.ts
+++ b/src/types/cypress/12.0.0/cypress.ts
@@ -65,6 +65,11 @@ export type ConfigOptions<ComponentDevServerOpts = unknown> = Partial<
 > & {
     hosts?: null | Record<string, string>;
 };
+export interface PluginConfigOptions extends ResolvedConfigOptions, RuntimeConfigOptions {
+    projectRoot: string;
+    testingType: TestingType;
+    version: string;
+}
 interface Auth {
     username: string;
     password: string;
@@ -221,11 +226,6 @@ type UserConfigOptions<ComponentDevServerOpts = unknown> = Omit<
     ResolvedConfigOptions<ComponentDevServerOpts>,
     "baseUrl" | "excludeSpecPattern" | "supportFile" | "specPattern" | "indexHtmlFile"
 >;
-interface PluginConfigOptions extends ResolvedConfigOptions, RuntimeConfigOptions {
-    projectRoot: string;
-    testingType: TestingType;
-    version: string;
-}
 interface DevServerConfig {
     specs: Spec[];
     cypressConfig: PluginConfigOptions;

--- a/src/types/cypress/cypress.ts
+++ b/src/types/cypress/cypress.ts
@@ -2,6 +2,8 @@ import {
     CypressRunResult as CypressRunResult_V_12,
     RunResult as RunResult_V_12,
 } from "./12.0.0/api";
+import { PluginConfigOptions as PluginConfigOptions_V_12 } from "./12.0.0/cypress";
 
 export type RunResultType = RunResult_V_12 | CypressCommandLine.RunResult;
 export type CypressRunResultType = CypressRunResult_V_12 | CypressCommandLine.CypressRunResult;
+export type PluginConfigOptions = PluginConfigOptions_V_12 | Cypress.PluginConfigOptions;


### PR DESCRIPTION
See https://github.com/Qytera-Gmbh/cypress-xray-plugin/issues/337#issuecomment-2155993197.

- `plugin.logDirectory` now resolves relative paths with respect to the project root
- fixes an issue where the plugin fails to find the generated Cucumber JSON report if a config file is provided using `npx cypress run --config-file`