### PR TITLE
Bump cypress-xray-plugin from 7.1.0 to 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,30 @@
 # Changelog
 
+# `7.2.0`
+
+## Notable changes
+
+-   Added `jira.testExecutionIssue` option ([#372](https://github.com/Qytera-Gmbh/cypress-xray-plugin/pull/372))
+
+-   Deprecated `jira.testExecutionIssueDescription` option
+
+-   Deprecated `jira.testExecutionIssueKey` option
+
+-   Deprecated `jira.testExecutionIssueSummary` option
+
+-   Deprecated `jira.testExecutionIssueType` option
+
+-   Added `http.rateLimiting` options ([#373](https://github.com/Qytera-Gmbh/cypress-xray-plugin/pull/373))
+
+## Dependency updates
+
+-   Bump @badeball/cypress-cucumber-preprocessor from 20.0.3 to 20.1.0
+
 # `7.1.0`
 
 > [!NOTE]
 > This version includes a complete rewrite of the plugin for maintainability reasons.
-> From a user perspective, it should now be slightly faster overall due to parallelization of feature file or result uploads.
+> From a user perspective, it should now be slightly faster overall due to concurrency of feature file or result uploads.
 > Its output has also been cleaned up and it will now only jump into action at the end of a Cypress run once all tests have concluded.
 > If any bugs have slipped through the extensive unit and integration tests, [please file a bug](https://github.com/Qytera-Gmbh/cypress-xray-plugin/issues).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,13 @@
 
 ## Dependency updates
 
--   Bump @badeball/cypress-cucumber-preprocessor from 20.0.3 to 20.1.0
+-   Bump @bahmutov/cypress-esbuild-preprocessor from 2.2.1 to 2.2.2
+
+-   Bump @badeball/cypress-cucumber-preprocessor from 20.1.0 to 20.1.1
+
+-   Bump semver from 7.6.2 to 7.6.3
+
+-   Bump cypress from 13.10.0 to 13.13.2
 
 # `7.1.0`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cypress-xray-plugin",
-    "version": "7.1.0",
+    "version": "7.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cypress-xray-plugin",
-            "version": "7.1.0",
+            "version": "7.2.0",
             "license": "MIT",
             "dependencies": {
                 "@cucumber/gherkin": "^28.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cypress-xray-plugin",
-    "version": "7.1.0",
+    "version": "7.2.0",
     "description": "A Cypress plugin for uploading test results to Xray (test management for Jira)",
     "types": "index.d.ts",
     "author": "csvtuda",


### PR DESCRIPTION
- Use multipart upload for results import
  - #349 
  - #359
  - #369 
  - [x] implemented
  - [x] tests done
  - [x] documentation updated: https://github.com/Qytera-Gmbh/Qytera-Gmbh.github.io/pull/64

- Allow multiple issue keys in test titles
  - #328
  - [x] implemented
  - [x] tests done
  - [x] documentation updated (not necessary)

- Add rate limiting
  - #370 
  - #366 
  - [x] implemented
  - [x] tests done
  - [x] documentation updated: https://github.com/Qytera-Gmbh/Qytera-Gmbh.github.io/pull/64