### PR TITLE
Add dynamic test execution data configuration

### DIFF
--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -1164,20 +1164,6 @@ describe(path.relative(process.cwd(), __filename), () => {
                         "Plugin misconfiguration: test execution issue key ABC-123 does not belong to project CYP"
                     );
                 });
-                it("detects mismatched test plan issue keys", () => {
-                    expect(() =>
-                        initJiraOptions(
-                            {},
-                            {
-                                projectKey: "CYP",
-                                testPlanIssueKey: "ABC-456",
-                                url: "https://example.org",
-                            }
-                        )
-                    ).to.throw(
-                        "Plugin misconfiguration: test plan issue key ABC-456 does not belong to project CYP"
-                    );
-                });
                 it("throws if the cucumber preprocessor is not installed", async () => {
                     stub(dependencies, "IMPORT").rejects(new Error("Failed to import package"));
                     await expect(

--- a/src/context.ts
+++ b/src/context.ts
@@ -144,11 +144,6 @@ export function initJiraOptions(
     }
     const testPlanIssueKey =
         parse(env, ENV_NAMES.jira.testPlanIssueKey, asString) ?? options.testPlanIssueKey;
-    if (testPlanIssueKey && !testPlanIssueKey.startsWith(projectKey)) {
-        throw new Error(
-            `Plugin misconfiguration: test plan issue key ${testPlanIssueKey} does not belong to project ${projectKey}`
-        );
-    }
     return {
         attachVideos:
             parse(env, ENV_NAMES.jira.attachVideos, asBoolean) ?? options.attachVideos ?? false,

--- a/src/hooks/after/after-run.ts
+++ b/src/hooks/after/after-run.ts
@@ -4,6 +4,7 @@ import { EvidenceCollection } from "../../context";
 import { CypressRunResultType } from "../../types/cypress/cypress";
 import { IssueUpdate } from "../../types/jira/responses/issue-update";
 import { ClientCombination, InternalCypressXrayPluginOptions } from "../../types/plugin";
+import { MaybeFunction } from "../../types/util";
 import { CucumberMultipartFeature } from "../../types/xray/requests/import-execution-cucumber-multipart";
 import { ExecutableGraph } from "../../util/graph/executable-graph";
 import { Level, Logger } from "../../util/logging";
@@ -402,7 +403,7 @@ function getConvertMultipartInfoCommand(
     if (convertCommand) {
         return convertCommand;
     }
-    let textExecutionIssueDataCommand: Command<IssueUpdate> | undefined;
+    let textExecutionIssueDataCommand: Command<MaybeFunction<IssueUpdate>> | undefined;
     if (options.jira.testExecutionIssue) {
         textExecutionIssueDataCommand = getOrCreateConstantCommand(
             graph,

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -4,6 +4,7 @@ import { AxiosRestClient, RequestsOptions } from "../client/https/requests";
 import { JiraClient } from "../client/jira/jira-client";
 import { XrayClient } from "../client/xray/xray-client";
 import { IssueUpdate } from "./jira/responses/issue-update";
+import { MaybeFunction } from "./util";
 
 /**
  * Models all options for configuring the behaviour of the plugin.
@@ -174,17 +175,17 @@ export interface JiraOptions {
      * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post
      * @see https://developer.atlassian.com/server/jira/platform/rest/v10000/api-group-issue/#api-api-2-issue-post
      */
-    testExecutionIssue?: IssueUpdate & {
-        /**
-         * An execution issue key to attach run results to. If omitted, Jira will always create a new
-         * test execution issue with each upload.
-         *
-         * *Note: it must be prefixed with the project key.*
-         *
-         * @example "CYP-123"
-         */
-        key?: string;
-    };
+    testExecutionIssue?: MaybeFunction<
+        IssueUpdate & {
+            /**
+             * An execution issue key to attach run results to. If omitted, Jira will always create a new
+             * test execution issue with each upload.
+             *
+             * @example "CYP-123"
+             */
+            key?: string;
+        }
+    >;
     /**
      * The description of the test execution issue, which will be used both for new test execution
      * issues as well as for updating existing issues (if provided through
@@ -291,7 +292,7 @@ export interface JiraOptions {
      *
      * @example "CYP-567"
      */
-    testPlanIssueKey?: string;
+    testPlanIssueKey?: MaybeFunction<string>;
     /**
      * The issue type name of test plans. By default, Xray calls them `Test Plan`, but it's possible
      * that they have been renamed or translated in your Jira instance.

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -46,3 +46,8 @@ export type Remap<T extends object, V, E extends number | string | symbol = neve
             : Remap<Required<T>[K], V, E>
         : V;
 };
+
+/**
+ * Represents a value that may be wrapped in a callback.
+ */
+export type MaybeFunction<T> = (() => Promise<T> | T) | T;

--- a/src/util/functions.spec.ts
+++ b/src/util/functions.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from "chai";
+import path from "node:path";
+import { getOrCall } from "./functions";
+
+describe(path.relative(process.cwd(), __filename), () => {
+    describe(getOrCall.name, () => {
+        it("returns unwrapped values", async () => {
+            expect(await getOrCall("hello")).to.eq("hello");
+        });
+
+        it("resolves sync callbacks", async () => {
+            expect(await getOrCall(() => 5)).to.eq(5);
+        });
+
+        it("resolves async callbacks", async () => {
+            expect(
+                await getOrCall(async () => {
+                    return new Promise((resolve) => {
+                        resolve(5);
+                    });
+                })
+            ).to.eq(5);
+        });
+    });
+});

--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -1,0 +1,20 @@
+import { MaybeFunction } from "../types/util";
+
+/**
+ * If the value is a function, evaluates it and returns the result. Otherwise, the value will be
+ * returned immediately.
+ *
+ * @param value - the value
+ * @returns the value or the callback result
+ */
+export async function getOrCall<T>(value: MaybeFunction<T>): Promise<T> {
+    // See https://github.com/microsoft/TypeScript/issues/37663#issuecomment-1081610403
+    if (isFunction(value)) {
+        return await value();
+    }
+    return value;
+}
+
+function isFunction<T extends (...args: unknown[]) => unknown>(value: unknown): value is T {
+    return typeof value === "function";
+}

--- a/test/integration/359.spec.ts
+++ b/test/integration/359.spec.ts
@@ -32,10 +32,10 @@ describe.only(path.relative(process.cwd(), __filename), () => {
         },
         {
             expectedLabels: ["x", "y"],
+            expectedSummary: "Integration test 359 (wrapped)",
             manualTest: "CYP-1139",
             projectKey: "CYP",
             service: "cloud",
-            summary: "Integration test 359 (wrapped)",
             testExecutionIssueData: dedent(`
                 () => {
                     return {
@@ -51,10 +51,10 @@ describe.only(path.relative(process.cwd(), __filename), () => {
         },
         {
             expectedLabels: [],
+            expectedSummary: "Integration test 359 (hardcoded)",
             manualTest: "CYPLUG-461",
             projectKey: "CYPLUG",
             service: "server",
-            summary: "Integration test 359 (hardcoded)",
             testExecutionIssueData: dedent(`
                 {
                     fields: {
@@ -68,10 +68,10 @@ describe.only(path.relative(process.cwd(), __filename), () => {
         },
         {
             expectedLabels: ["x", "y"],
+            expectedSummary: "Integration test 359 (wrapped)",
             manualTest: "CYPLUG-461",
             projectKey: "CYPLUG",
             service: "server",
-            summary: "Integration test 359 (wrapped)",
             testExecutionIssueData: dedent(`
                 () => {
                     return {

--- a/test/integration/359.spec.ts
+++ b/test/integration/359.spec.ts
@@ -1,0 +1,162 @@
+import { expect } from "chai";
+import path from "path";
+import process from "process";
+import { dedent } from "../../src/util/dedent";
+import { LOCAL_SERVER } from "../server-config";
+import { runCypress, setupCypressProject } from "../sh";
+import { getIntegrationClient } from "./clients";
+import { getCreatedTestExecutionIssueKey } from "./util";
+
+// ============================================================================================== //
+// https://github.com/Qytera-Gmbh/cypress-xray-plugin/issues/359
+// ============================================================================================== //
+
+describe.only(path.relative(process.cwd(), __filename), () => {
+    for (const test of [
+        {
+            expectedLabels: [],
+            expectedSummary: "Integration test 359 (hardcoded)",
+            manualTest: "CYP-1139",
+            projectKey: "CYP",
+            service: "cloud",
+            testExecutionIssueData: dedent(`
+                {
+                    fields: {
+                        summary: "Integration test 359 (hardcoded)",
+                        labels: LABELS
+                    }
+                }
+            `),
+            title: "test execution issue data is hardcoded (cloud)",
+            xrayPassedStatus: "PASSED",
+        },
+        {
+            labels: ["x", "y"],
+            manualTest: "CYP-1139",
+            projectKey: "CYP",
+            service: "cloud",
+            summary: "Integration test 359 (wrapped)",
+            testExecutionIssueData: dedent(`
+                () => {
+                    return {
+                        fields: {
+                            summary: "Integration test 359 (wrapped)",
+                            labels: LABELS
+                        }
+                    };
+                }
+            `),
+            title: "test execution issue data is wrapped (cloud)",
+            xrayPassedStatus: "PASSED",
+        },
+        {
+            labels: [],
+            manualTest: "CYPLUG-461",
+            projectKey: "CYPLUG",
+            service: "server",
+            summary: "Integration test 359 (hardcoded)",
+            testExecutionIssueData: dedent(`
+                {
+                    fields: {
+                        summary: "Integration test 359 (hardcoded)",
+                        labels: LABELS
+                    }
+                }
+            `),
+            title: "test execution issue data is hardcoded (server)",
+            xrayPassedStatus: "PASS",
+        },
+        {
+            labels: ["x", "y"],
+            manualTest: "CYPLUG-461",
+            projectKey: "CYPLUG",
+            service: "server",
+            summary: "Integration test 359 (wrapped)",
+            testExecutionIssueData: dedent(`
+                () => {
+                    return {
+                        fields: {
+                            summary: "Integration test 359 (wrapped)",
+                            labels: LABELS
+                        }
+                    };
+                }
+            `),
+            title: "test execution issue data is wrapped (server)",
+            xrayPassedStatus: "PASS",
+        },
+    ] as const) {
+        it(test.title, async () => {
+            const project = setupCypressProject({
+                configFileContent: dedent(`
+                    const { defineConfig } = require("cypress");
+                    const fix = require("cypress-on-fix");
+                    const { configureXrayPlugin } = require("cypress-xray-plugin");
+
+                    const LABELS = [];
+
+                    module.exports = defineConfig({
+                        video: false,
+                        chromeWebSecurity: false,
+                        e2e: {
+                            specPattern: "**/*.cy.js",
+                            async setupNodeEvents(on, config) {
+                                const fixedOn = fix(on);
+                                await configureXrayPlugin(fixedOn, config, {
+                                    jira: {
+                                        projectKey: "CYP",
+                                        testExecutionIssue: ${test.testExecutionIssueData}
+                                    },
+                                    xray: {
+                                        uploadResults: true,
+                                        testEnvironments: ["DEV"],
+                                        status: {
+                                            passed: "${test.xrayPassedStatus}"
+                                        }
+                                    },
+                                    plugin: {
+                                        debug: true,
+                                    },
+                                });
+                                fixedOn("task", {
+                                    "update-labels": (values) => LABELS.push(...values)
+                                });
+                                return config;
+                            },
+                        },
+                    });
+                `),
+                testFiles: [
+                    {
+                        content: dedent(`
+                            describe("${test.manualTest} template spec", () => {
+                                it("passes", () => {
+                                    cy.visit("${LOCAL_SERVER.url}");
+                                    cy.task("update-labels", ${JSON.stringify(test.expectedLabels)})
+                                });
+                            });
+                        `),
+                        fileName: "spec.cy.js",
+                    },
+                ],
+            });
+
+            const output = runCypress(project.projectDirectory, {
+                includeDefaultEnv: test.service,
+            });
+
+            const testExecutionIssueKey = getCreatedTestExecutionIssueKey(
+                test.projectKey,
+                output,
+                "cypress"
+            );
+
+            const searchResult = await getIntegrationClient("jira", test.service).search({
+                fields: ["labels", "summary"],
+                jql: `issue in (${testExecutionIssueKey})`,
+            });
+            expect(searchResult[0].fields?.labels).to.deep.eq(test.expectedLabels);
+            expect(searchResult[0].fields?.summary).to.deep.eq(test.expectedSummary);
+        });
+    }
+});

--- a/test/integration/359.spec.ts
+++ b/test/integration/359.spec.ts
@@ -115,7 +115,7 @@ describe.only(path.relative(process.cwd(), __filename), () => {
                                         }
                                     },
                                     plugin: {
-                                        debug: true,
+                                        debug: false,
                                     },
                                 });
                                 fixedOn("task", {

--- a/test/integration/359.spec.ts
+++ b/test/integration/359.spec.ts
@@ -31,7 +31,7 @@ describe.only(path.relative(process.cwd(), __filename), () => {
             xrayPassedStatus: "PASSED",
         },
         {
-            labels: ["x", "y"],
+            expectedLabels: ["x", "y"],
             manualTest: "CYP-1139",
             projectKey: "CYP",
             service: "cloud",
@@ -50,7 +50,7 @@ describe.only(path.relative(process.cwd(), __filename), () => {
             xrayPassedStatus: "PASSED",
         },
         {
-            labels: [],
+            expectedLabels: [],
             manualTest: "CYPLUG-461",
             projectKey: "CYPLUG",
             service: "server",
@@ -67,7 +67,7 @@ describe.only(path.relative(process.cwd(), __filename), () => {
             xrayPassedStatus: "PASS",
         },
         {
-            labels: ["x", "y"],
+            expectedLabels: ["x", "y"],
             manualTest: "CYPLUG-461",
             projectKey: "CYPLUG",
             service: "server",

--- a/test/sh.ts
+++ b/test/sh.ts
@@ -160,6 +160,17 @@ export function runCypress(
         ...mergedEnv,
         ...options?.env,
     };
+    fs.writeFileSync(
+        path.join(cwd, "cypress.env.json"),
+        JSON.stringify(
+            mergedEnv,
+            (...args) => {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+                return args[1] ? args[1] : undefined;
+            },
+            2
+        ).replaceAll("CYPRESS_", "")
+    );
     const result = childProcess.spawnSync(CYPRESS_EXECUTABLE, ["run"], {
         cwd: cwd,
         env: mergedEnv,


### PR DESCRIPTION
It's now possible to supply a function to `jira.testExecutionIssue`, which will be evaluated at the end of the Cypress tests, just before the results upload:

```ts
await configureXrayPlugin(on, config, {
  jira: {
    projectKey: "CYP",
    testExecutionIssue: () => {
      return {
        // ...
      };
    }
  },
});
```