### PR TITLE
Fix rate limit time saving

### DIFF
--- a/src/client/https/requests.ts
+++ b/src/client/https/requests.ts
@@ -331,7 +331,12 @@ export class AxiosRestClient {
         if (this.options?.rateLimiting?.requestsPerSecond) {
             const interval = 1000 / this.options.rateLimiting.requestsPerSecond;
             const now = Date.now();
-            const nextRequestTime = this.lastRequestTime ? this.lastRequestTime + interval : now;
+            let nextRequestTime: number;
+            if (this.lastRequestTime) {
+                nextRequestTime = Math.max(this.lastRequestTime + interval, now);
+            } else {
+                nextRequestTime = now;
+            }
             this.lastRequestTime = nextRequestTime;
             const delay = nextRequestTime - now;
             if (delay > 0) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -359,25 +359,25 @@ export function initHttpClients(
     if (httpOptions) {
         const { jira, rateLimiting: rateLimitingCommon, xray, ...httpConfigCommon } = httpOptions;
         if (jira) {
-            const { rateLimiting, ...httpConfig } = jira;
+            const { rateLimiting: rateLimitingJira, ...httpConfig } = jira;
             jiraClient = new AxiosRestClient({
                 debug: pluginOptions?.debug,
                 http: {
                     ...httpConfigCommon,
                     ...httpConfig,
                 },
-                rateLimiting: rateLimiting ?? rateLimitingCommon,
+                rateLimiting: rateLimitingJira ?? rateLimitingCommon,
             });
         }
         if (xray) {
-            const { rateLimiting, ...httpConfig } = xray;
+            const { rateLimiting: rateLimitingXray, ...httpConfig } = xray;
             xrayClient = new AxiosRestClient({
                 debug: pluginOptions?.debug,
                 http: {
                     ...httpConfigCommon,
                     ...httpConfig,
                 },
-                rateLimiting: rateLimiting ?? rateLimitingCommon,
+                rateLimiting: rateLimitingXray ?? rateLimitingCommon,
             });
         }
         if (!jiraClient || !xrayClient) {

--- a/src/hooks/after/after-run.ts
+++ b/src/hooks/after/after-run.ts
@@ -125,12 +125,15 @@ export function addUploadCommands(
         if (options.cucumber.uploadFeatures) {
             for (const importFeatureCommand of graph.getVertices()) {
                 if (importFeatureCommand instanceof ImportFeatureCommand) {
+                    const filePath = path.relative(
+                        projectRoot,
+                        importFeatureCommand.getParameters().filePath
+                    );
                     if (
-                        runResult.runs.some(
-                            (run) =>
-                                path.relative(projectRoot, run.spec.relative) ===
-                                importFeatureCommand.getParameters().filePath
-                        )
+                        runResult.runs.some((run) => {
+                            const specPath = path.relative(projectRoot, run.spec.relative);
+                            return specPath === filePath;
+                        })
                     ) {
                         // We can still upload results even if the feature file import fails. It's
                         // better to upload mismatched results than none at all.

--- a/test/integration/359.spec.ts
+++ b/test/integration/359.spec.ts
@@ -11,7 +11,7 @@ import { getCreatedTestExecutionIssueKey } from "./util";
 // https://github.com/Qytera-Gmbh/cypress-xray-plugin/issues/359
 // ============================================================================================== //
 
-describe.only(path.relative(process.cwd(), __filename), () => {
+describe(path.relative(process.cwd(), __filename), () => {
     for (const test of [
         {
             expectedLabels: [],


### PR DESCRIPTION
The rate limiter currently saves "unused" time and may consume it all at once when new requests are dispatched, resulting in lots of requests being dispatched at the same time if enough time was saved.

This PR fixes the issue through `Math.max(now, lastRequestTime + delay)`.