### PR TITLE
Add Xray status aggregation option

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     },
     "scripts": {
         "test": "node --require ./test/loader.js ./test/run-unit-tests.ts",
-        "test:coverage": "npx shx mkdir -p coverage && c8 -x **/*.spec.ts -r html npm run test",
+        "test:coverage": "npx shx mkdir -p coverage && c8 -x '**/*.spec.ts' -r html npm run test",
         "test:integration": "node --require ./test/loader.js ./test/run-integration-tests.ts",
         "test:server": "node --require ./test/loader.js ./test/run-server.ts",
         "build": "tsc --project tsconfig-build.json && shx cp package.json README.md LICENSE.md CHANGELOG.md dist/",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     },
     "scripts": {
         "test": "node --require ./test/loader.js ./test/run-unit-tests.ts",
-        "test:coverage": "npx shx mkdir -p coverage && c8 -r html npm run test",
+        "test:coverage": "npx shx mkdir -p coverage && c8 -x **/*.spec.ts -r html npm run test",
         "test:integration": "node --require ./test/loader.js ./test/run-integration-tests.ts",
         "test:server": "node --require ./test/loader.js ./test/run-server.ts",
         "build": "tsc --project tsconfig-build.json && shx cp package.json README.md LICENSE.md CHANGELOG.md dist/",

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,32 +1,7 @@
-import type { CypressXrayPluginOptions } from "./types/plugin";
-import type { Remap } from "./types/util";
-
-/**
- * An interface containing all authentication options which can be provided via environment
- * variables.
- */
-interface Authentication {
-    authentication: {
-        jira: {
-            apiToken: string;
-            password: string;
-            username: string;
-        };
-        xray: {
-            clientId: string;
-            clientSecret: string;
-        };
-    };
-}
-
 /**
  * Contains a mapping of all available options to their respective environment variable names.
  */
-export const ENV_NAMES: Remap<
-    Omit<CypressXrayPluginOptions, "http"> & Authentication,
-    string,
-    ["testExecutionIssue"]
-> = {
+export const ENV_NAMES = {
     authentication: {
         jira: {
             apiToken: "JIRA_API_TOKEN",

--- a/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.spec.ts
+++ b/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.spec.ts
@@ -345,18 +345,19 @@ describe(relative(cwd(), __filename), async () => {
                         normalizeScreenshotNames: false,
                         projectKey: "CYP",
                         uploadScreenshots: true,
+                        useCloudStatusFallback: true,
                         xrayStatus: options.xray.status,
                     },
                     LOG,
                     new ConstantCommand(LOG, result)
                 );
                 const tests = await command.compute();
-                assert.strictEqual(tests[0].status, "PASS");
+                assert.strictEqual(tests[0].status, "PASSED");
                 assert.ok(tests[0].iterations);
-                assert.strictEqual(tests[0].iterations[0].status, "PASS");
-                assert.strictEqual(tests[0].iterations[1].status, "PASS");
-                assert.strictEqual(tests[0].iterations[2].status, "PASS");
-                assert.strictEqual(tests[0].iterations[3].status, "PASS");
+                assert.strictEqual(tests[0].iterations[0].status, "PASSED");
+                assert.strictEqual(tests[0].iterations[1].status, "PASSED");
+                assert.strictEqual(tests[0].iterations[2].status, "PASSED");
+                assert.strictEqual(tests[0].iterations[3].status, "PASSED");
             });
 
             await it("uses default iterated pending statuses", async (context) => {
@@ -374,18 +375,19 @@ describe(relative(cwd(), __filename), async () => {
                         normalizeScreenshotNames: false,
                         projectKey: "CYP",
                         uploadScreenshots: true,
+                        useCloudStatusFallback: true,
                         xrayStatus: options.xray.status,
                     },
                     LOG,
                     new ConstantCommand(LOG, result)
                 );
                 const tests = await command.compute();
-                assert.strictEqual(tests[0].status, "TODO");
+                assert.strictEqual(tests[0].status, "TO DO");
                 assert.ok(tests[0].iterations);
-                assert.strictEqual(tests[0].iterations[0].status, "TODO");
-                assert.strictEqual(tests[0].iterations[1].status, "TODO");
-                assert.strictEqual(tests[0].iterations[2].status, "TODO");
-                assert.strictEqual(tests[0].iterations[3].status, "TODO");
+                assert.strictEqual(tests[0].iterations[0].status, "TO DO");
+                assert.strictEqual(tests[0].iterations[1].status, "TO DO");
+                assert.strictEqual(tests[0].iterations[2].status, "TO DO");
+                assert.strictEqual(tests[0].iterations[3].status, "TO DO");
             });
 
             await it("uses default iterated skipped statuses", async (context) => {
@@ -403,18 +405,19 @@ describe(relative(cwd(), __filename), async () => {
                         normalizeScreenshotNames: false,
                         projectKey: "CYP",
                         uploadScreenshots: true,
+                        useCloudStatusFallback: true,
                         xrayStatus: options.xray.status,
                     },
                     LOG,
                     new ConstantCommand(LOG, result)
                 );
                 const tests = await command.compute();
-                assert.strictEqual(tests[0].status, "FAIL");
+                assert.strictEqual(tests[0].status, "FAILED");
                 assert.ok(tests[0].iterations);
-                assert.strictEqual(tests[0].iterations[0].status, "TODO");
-                assert.strictEqual(tests[0].iterations[1].status, "TODO");
-                assert.strictEqual(tests[0].iterations[2].status, "TODO");
-                assert.strictEqual(tests[0].iterations[3].status, "FAIL");
+                assert.strictEqual(tests[0].iterations[0].status, "TO DO");
+                assert.strictEqual(tests[0].iterations[1].status, "TO DO");
+                assert.strictEqual(tests[0].iterations[2].status, "TO DO");
+                assert.strictEqual(tests[0].iterations[3].status, "FAILED");
             });
 
             await it("uses default iterated failed statuses", async (context) => {
@@ -428,21 +431,22 @@ describe(relative(cwd(), __filename), async () => {
                         normalizeScreenshotNames: false,
                         projectKey: "CYP",
                         uploadScreenshots: true,
+                        useCloudStatusFallback: true,
                         xrayStatus: options.xray.status,
                     },
                     LOG,
                     new ConstantCommand(LOG, result)
                 );
                 const tests = await command.compute();
-                assert.strictEqual(tests[0].status, "FAIL");
+                assert.strictEqual(tests[0].status, "FAILED");
                 assert.ok(tests[0].iterations);
-                assert.strictEqual(tests[0].iterations[0].status, "FAIL");
-                assert.strictEqual(tests[0].iterations[1].status, "FAIL");
-                assert.strictEqual(tests[0].iterations[2].status, "PASS");
-                assert.strictEqual(tests[0].iterations[3].status, "PASS");
+                assert.strictEqual(tests[0].iterations[0].status, "FAILED");
+                assert.strictEqual(tests[0].iterations[1].status, "FAILED");
+                assert.strictEqual(tests[0].iterations[2].status, "PASSED");
+                assert.strictEqual(tests[0].iterations[3].status, "PASSED");
             });
 
-            await it("uses custom iterated statuses", async (context) => {
+            await it("uses custom reduced statuses", async (context) => {
                 context.mock.method(LOG, "message", context.mock.fn());
                 const result: CypressRunResultType = JSON.parse(
                     readFileSync("./test/resources/iteratedResult_13_16_0.json", "utf-8")
@@ -453,6 +457,7 @@ describe(relative(cwd(), __filename), async () => {
                         normalizeScreenshotNames: false,
                         projectKey: "CYP",
                         uploadScreenshots: true,
+                        useCloudStatusFallback: true,
                         xrayStatus: {
                             reduce: ({ failed, passed, pending, skipped }) => {
                                 if (passed > 0 && failed === 0 && skipped === 0) {
@@ -473,6 +478,11 @@ describe(relative(cwd(), __filename), async () => {
                 );
                 const tests = await command.compute();
                 assert.strictEqual(tests[0].status, "FLAKY");
+                assert.ok(tests[0].iterations);
+                assert.strictEqual(tests[0].iterations[0].status, "FAILED");
+                assert.strictEqual(tests[0].iterations[1].status, "FAILED");
+                assert.strictEqual(tests[0].iterations[2].status, "PASSED");
+                assert.strictEqual(tests[0].iterations[3].status, "PASSED");
             });
         });
 
@@ -933,7 +943,7 @@ describe(relative(cwd(), __filename), async () => {
             assert.strictEqual(tests[0].iterations[3].status, "PASS");
         });
 
-        await it("uses custom iterated statuses", async (context) => {
+        await it("uses custom reduced statuses", async (context) => {
             context.mock.method(LOG, "message", context.mock.fn());
             const result: CypressRunResultType = JSON.parse(
                 readFileSync("./test/resources/iteratedResult.json", "utf-8")
@@ -964,6 +974,11 @@ describe(relative(cwd(), __filename), async () => {
             );
             const tests = await command.compute();
             assert.strictEqual(tests[0].status, "FLAKY");
+            assert.ok(tests[0].iterations);
+            assert.strictEqual(tests[0].iterations[0].status, "FAIL");
+            assert.strictEqual(tests[0].iterations[1].status, "FAIL");
+            assert.strictEqual(tests[0].iterations[2].status, "PASS");
+            assert.strictEqual(tests[0].iterations[3].status, "PASS");
         });
 
         await it("does not modify test information", async (context) => {

--- a/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.spec.ts
+++ b/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.spec.ts
@@ -446,7 +446,7 @@ describe(relative(cwd(), __filename), async () => {
                 assert.strictEqual(tests[0].iterations[3].status, "PASSED");
             });
 
-            await it("uses custom reduced statuses", async (context) => {
+            await it("uses custom aggregated statuses", async (context) => {
                 context.mock.method(LOG, "message", context.mock.fn());
                 const result: CypressRunResultType = JSON.parse(
                     readFileSync("./test/resources/iteratedResult_13_16_0.json", "utf-8")
@@ -459,7 +459,7 @@ describe(relative(cwd(), __filename), async () => {
                         uploadScreenshots: true,
                         useCloudStatusFallback: true,
                         xrayStatus: {
-                            reduce: ({ failed, passed, pending, skipped }) => {
+                            aggregate: ({ failed, passed, pending, skipped }) => {
                                 if (passed > 0 && failed === 0 && skipped === 0) {
                                     return "PASSED";
                                 }
@@ -943,7 +943,7 @@ describe(relative(cwd(), __filename), async () => {
             assert.strictEqual(tests[0].iterations[3].status, "PASS");
         });
 
-        await it("uses custom reduced statuses", async (context) => {
+        await it("uses custom aggregated statuses", async (context) => {
             context.mock.method(LOG, "message", context.mock.fn());
             const result: CypressRunResultType = JSON.parse(
                 readFileSync("./test/resources/iteratedResult.json", "utf-8")
@@ -955,7 +955,7 @@ describe(relative(cwd(), __filename), async () => {
                     projectKey: "CYP",
                     uploadScreenshots: true,
                     xrayStatus: {
-                        reduce: ({ failed, passed, pending, skipped }) => {
+                        aggregate: ({ failed, passed, pending, skipped }) => {
                             if (passed > 0 && failed === 0 && skipped === 0) {
                                 return "PASSED";
                             }

--- a/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.ts
+++ b/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.ts
@@ -78,7 +78,7 @@ export class ConvertCypressTestsCommand extends Command<[XrayTest, ...XrayTest[]
                 );
             }
         });
-        for (const [issueKey, testRuns] of runsByKey.entries()) {
+        for (const [issueKey, testRuns] of runsByKey) {
             const test: XrayTest = this.getTest(testRuns, issueKey, this.getXrayEvidence(issueKey));
             xrayTests.push(test);
         }
@@ -114,9 +114,11 @@ export class ConvertCypressTestsCommand extends Command<[XrayTest, ...XrayTest[]
         };
         for (const run of cypressRuns) {
             const testRuns = extractor(run);
-            testRuns.forEach((promise, index) =>
-                conversionPromises.push([run.tests[index].title.join(" "), promise])
-            );
+            for (const [title, promises] of testRuns) {
+                for (const promise of promises) {
+                    conversionPromises.push([title, promise]);
+                }
+            }
         }
         if (this.parameters.uploadScreenshots) {
             this.addScreenshotEvidence(runResults, version);
@@ -162,7 +164,7 @@ export class ConvertCypressTestsCommand extends Command<[XrayTest, ...XrayTest[]
         const includedScreenshots: string[] = [];
         for (const run of runResults.runs) {
             const allScreenshots = extractor(run);
-            for (const [issueKey, screenshots] of allScreenshots.entries()) {
+            for (const [issueKey, screenshots] of allScreenshots) {
                 for (const screenshot of screenshots) {
                     let filename = path.basename(screenshot);
                     if (this.parameters.normalizeScreenshotNames) {

--- a/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.ts
+++ b/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.ts
@@ -251,8 +251,8 @@ export class ConvertCypressTestsCommand extends Command<[XrayTest, ...XrayTest[]
             const failed = statuses.filter((s) => s === CypressStatus.FAILED).length;
             const pending = statuses.filter((s) => s === CypressStatus.PENDING).length;
             const skipped = statuses.filter((s) => s === CypressStatus.SKIPPED).length;
-            if (this.parameters.xrayStatus.reduce) {
-                return this.parameters.xrayStatus.reduce({ failed, passed, pending, skipped });
+            if (this.parameters.xrayStatus.aggregate) {
+                return this.parameters.xrayStatus.aggregate({ failed, passed, pending, skipped });
             }
             if (passed > 0 && failed === 0 && skipped === 0) {
                 return getXrayStatus(

--- a/src/hooks/after/commands/conversion/cypress/util/run.spec.ts
+++ b/src/hooks/after/commands/conversion/cypress/util/run.spec.ts
@@ -182,7 +182,10 @@ describe(relative(cwd(), __filename), async () => {
         };
 
         await it("returns test data for valid runs", async () => {
-            const testRuns = getTestRunData_V12(passedResult);
+            const map = getTestRunData_V12(passedResult);
+            assert.strictEqual(map.size, 1);
+            const testRuns = map.get("xray upload demo should look for paragraph elements");
+            assert.ok(testRuns);
             const resolvedTestData = await Promise.all(testRuns);
             assert.deepStrictEqual(resolvedTestData[0], {
                 duration: 244,
@@ -204,7 +207,10 @@ describe(relative(cwd(), __filename), async () => {
         });
 
         await it("rejects invalid runs", async () => {
-            const testRuns = getTestRunData_V12(invalidResult);
+            const map = getTestRunData_V12(invalidResult);
+            assert.strictEqual(map.size, 1);
+            const testRuns = map.get("xray upload demo should fail");
+            assert.ok(testRuns);
             const resolvedTestData = await Promise.allSettled(testRuns);
             assert.strictEqual(resolvedTestData[0].status, "rejected");
             const reason = resolvedTestData[0].reason as Error;
@@ -381,9 +387,11 @@ describe(relative(cwd(), __filename), async () => {
         };
 
         await it("returns test data for valid runs", async () => {
-            const testRuns = getTestRunData_V13(passedResult);
-            const resolvedTestData = await Promise.all(testRuns);
-            assert.deepStrictEqual(resolvedTestData, [
+            const map = getTestRunData_V13(passedResult);
+            assert.strictEqual(map.size, 2);
+            let testRuns = map.get("something CYP-237 happens");
+            assert.ok(testRuns);
+            assert.deepStrictEqual(await Promise.all(testRuns), [
                 {
                     duration: 638,
                     spec: {
@@ -393,6 +401,10 @@ describe(relative(cwd(), __filename), async () => {
                     status: CypressStatus.PASSED,
                     title: "something CYP-237 happens",
                 },
+            ]);
+            testRuns = map.get("something something");
+            assert.ok(testRuns);
+            assert.deepStrictEqual(await Promise.all(testRuns), [
                 {
                     duration: 123,
                     spec: {
@@ -422,7 +434,10 @@ describe(relative(cwd(), __filename), async () => {
         });
 
         await it("rejects invalid runs", async () => {
-            const testRuns = getTestRunData_V13(invalidResult);
+            const map = getTestRunData_V13(invalidResult);
+            assert.strictEqual(map.size, 1);
+            const testRuns = map.get("something CYP-237 happens");
+            assert.ok(testRuns);
             const resolvedTestData = await Promise.allSettled(testRuns);
             assert.strictEqual(resolvedTestData[0].status, "rejected");
             const reason = resolvedTestData[0].reason as Error;

--- a/src/hooks/after/commands/conversion/cypress/util/status.ts
+++ b/src/hooks/after/commands/conversion/cypress/util/status.ts
@@ -62,21 +62,17 @@ export function getXrayStatus(
     if (typeof status === "string") {
         return lookupStatus(status);
     }
-    const hasPassed = status.some((cypressStatus) => cypressStatus === CypressStatus.PASSED);
-    const hasFailed = status.some((cypressStatus) => cypressStatus === CypressStatus.FAILED);
-    const hasPending = status.some((cypressStatus) => cypressStatus === CypressStatus.PENDING);
-    const hasSkipped = status.some((cypressStatus) => cypressStatus === CypressStatus.SKIPPED);
-    if (hasPassed && !hasFailed && !hasPending && !hasSkipped) {
+    const passed = status.filter((s) => s === CypressStatus.PASSED).length;
+    const failed = status.filter((s) => s === CypressStatus.FAILED).length;
+    const pending = status.filter((s) => s === CypressStatus.PENDING).length;
+    const skipped = status.filter((s) => s === CypressStatus.SKIPPED).length;
+    if (passed > 0 && failed === 0 && skipped === 0) {
         return lookupStatus(CypressStatus.PASSED);
     }
-    if (hasPending && !hasFailed && !hasSkipped) {
+    if (passed === 0 && failed === 0 && skipped === 0 && pending > 0) {
         return lookupStatus(CypressStatus.PENDING);
     }
-    if (hasFailed && hasPassed) {
-        // TODO: return FLAKY
-        return lookupStatus(CypressStatus.PASSED);
-    }
-    if (hasSkipped && !hasFailed) {
+    if (skipped > 0) {
         return lookupStatus(CypressStatus.SKIPPED);
     }
     return lookupStatus(CypressStatus.FAILED);

--- a/src/hooks/after/commands/conversion/cypress/util/status.ts
+++ b/src/hooks/after/commands/conversion/cypress/util/status.ts
@@ -38,7 +38,7 @@ export function toCypressStatus(statusText: string): CypressStatus {
  * @returns the Xray status
  */
 export function getXrayStatus(
-    status: CypressStatus | CypressStatus[],
+    status: CypressStatus,
     useCloudStatus: boolean,
     statusOptions?: {
         failed?: string;
@@ -47,33 +47,14 @@ export function getXrayStatus(
         skipped?: string;
     }
 ): string {
-    const lookupStatus = (cypressStatus: CypressStatus) => {
-        switch (cypressStatus) {
-            case CypressStatus.PASSED:
-                return statusOptions?.passed ?? (useCloudStatus ? "PASSED" : "PASS");
-            case CypressStatus.FAILED:
-                return statusOptions?.failed ?? (useCloudStatus ? "FAILED" : "FAIL");
-            case CypressStatus.PENDING:
-                return statusOptions?.pending ?? (useCloudStatus ? "TO DO" : "TODO");
-            case CypressStatus.SKIPPED:
-                return statusOptions?.skipped ?? (useCloudStatus ? "FAILED" : "FAIL");
-        }
-    };
-    if (typeof status === "string") {
-        return lookupStatus(status);
+    switch (status) {
+        case CypressStatus.PASSED:
+            return statusOptions?.passed ?? (useCloudStatus ? "PASSED" : "PASS");
+        case CypressStatus.FAILED:
+            return statusOptions?.failed ?? (useCloudStatus ? "FAILED" : "FAIL");
+        case CypressStatus.PENDING:
+            return statusOptions?.pending ?? (useCloudStatus ? "TO DO" : "TODO");
+        case CypressStatus.SKIPPED:
+            return statusOptions?.skipped ?? (useCloudStatus ? "FAILED" : "FAIL");
     }
-    const passed = status.filter((s) => s === CypressStatus.PASSED).length;
-    const failed = status.filter((s) => s === CypressStatus.FAILED).length;
-    const pending = status.filter((s) => s === CypressStatus.PENDING).length;
-    const skipped = status.filter((s) => s === CypressStatus.SKIPPED).length;
-    if (passed > 0 && failed === 0 && skipped === 0) {
-        return lookupStatus(CypressStatus.PASSED);
-    }
-    if (passed === 0 && failed === 0 && skipped === 0 && pending > 0) {
-        return lookupStatus(CypressStatus.PENDING);
-    }
-    if (skipped > 0) {
-        return lookupStatus(CypressStatus.SKIPPED);
-    }
-    return lookupStatus(CypressStatus.FAILED);
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -364,31 +364,10 @@ export interface XrayOptions {
      */
     status?: {
         /**
-         * The Xray status name of a test marked as failed by Cypress. Should be used when custom
-         * status names have been set up in Xray.
-         *
-         * @example "FEHLGESCHLAGEN" // german
-         */
-        failed?: string;
-        /**
-         * The Xray status name of a test marked as passed by Cypress. Should be used when custom
-         * status names have been set up in Xray.
-         *
-         * @example "BESTANDEN" // german
-         */
-        passed?: string;
-        /**
-         * The Xray status name of a test marked as pending by Cypress. Should be used when custom
-         * status names have been set up in Xray.
-         *
-         * @example "EN_ATTENTE" // french
-         */
-        pending?: string;
-        /**
          * A function that returns a single status for a given combination of other statuses. It is
          * used to determine the final status of retried and data-driven tests.
          *
-         * By default, the reduction works as follows in order of mention:
+         * By default, the aggregation works as follows in order of mention:
          *
          * - a test is considered _passed_ if:
          *   - all iterations pass
@@ -418,10 +397,10 @@ export interface XrayOptions {
          * }
          * ```
          *
-         * @param args - the reduction arguments
-         * @returns the reduced status
+         * @param args - the aggregation arguments
+         * @returns the aggregated status
          */
-        reduce?: (args: {
+        aggregate?: (args: {
             /**
              * The number of iterations that have been reported as _failed_ by Cypress.
              *
@@ -447,6 +426,27 @@ export interface XrayOptions {
              */
             skipped: number;
         }) => string;
+        /**
+         * The Xray status name of a test marked as failed by Cypress. Should be used when custom
+         * status names have been set up in Xray.
+         *
+         * @example "FEHLGESCHLAGEN" // german
+         */
+        failed?: string;
+        /**
+         * The Xray status name of a test marked as passed by Cypress. Should be used when custom
+         * status names have been set up in Xray.
+         *
+         * @example "BESTANDEN" // german
+         */
+        passed?: string;
+        /**
+         * The Xray status name of a test marked as pending by Cypress. Should be used when custom
+         * status names have been set up in Xray.
+         *
+         * @example "EN_ATTENTE" // french
+         */
+        pending?: string;
         /**
          * The Xray status name of a test marked as skipped by Cypress. Should be used when custom
          * status names have been set up in Xray.

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -385,8 +385,8 @@ export interface XrayOptions {
          */
         pending?: string;
         /**
-         * A function that returns a single status for a given combination of other statuses. It
-         * will be used to determine the final status of retried and data-driven tests.
+         * A function that returns a single status for a given combination of other statuses. It is
+         * used to determine the final status of retried and data-driven tests.
          *
          * By default, the reduction works as follows in order of mention:
          *

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -385,6 +385,69 @@ export interface XrayOptions {
          */
         pending?: string;
         /**
+         * A function that returns a single status for a given combination of other statuses. It
+         * will be used to determine the final status of retried and data-driven tests.
+         *
+         * By default, the reduction works as follows in order of mention:
+         *
+         * - a test is considered _passed_ if:
+         *   - all iterations pass
+         *   - at least one iteration passes and all others are pending
+         * - a test is considered _pending_ if:
+         *   - all iterations are pending
+         * - a test is considered _skipped_ if:
+         *   - at least one iteration is skipped
+         * - the test is considered _failed_ in all other scenarios
+         *
+         * @example
+         *
+         * The following example defines a custom _FLAKY_ status:
+         *
+         * ```ts
+         * ({ failed, passed, pending, skipped }) => {
+         *   if (passed > 0 && failed === 0 && skipped === 0) {
+         *     return "PASSED";
+         *   }
+         *   if (passed > 0 && (failed > 0 || skipped > 0)) {
+         *     return "FLAKY";
+         *   }
+         *   if (pending > 0) {
+         *     return "TODO";
+         *   }
+         *   return "FAILED";
+         * }
+         * ```
+         *
+         * @param args - the reduction arguments
+         * @returns the reduced status
+         */
+        reduce?: (args: {
+            /**
+             * The number of iterations that have been reported as _failed_ by Cypress.
+             *
+             * @see https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Failed
+             */
+            failed: number;
+            /**
+             * The number of iterations that have been reported as _passed_ by Cypress.
+             *
+             * @see https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Passed
+             */
+            passed: number;
+            /**
+             * The number of iterations that have been reported as _pending_ by Cypress.
+             *
+             * @see https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Pending
+             */
+            pending: number;
+            /**
+             * The number of iterations that have been reported as _skipped_ by Cypress.
+             *
+             * @see https://docs.cypress.io/app/core-concepts/writing-and-organizing-tests#Skipped
+             */
+            skipped: number;
+        }) => string;
+        /**
          * The Xray status name of a test marked as skipped by Cypress. Should be used when custom
          * status names have been set up in Xray.
          *

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -7,51 +7,6 @@ export type DateTimeIso = string;
 export type StringMap<T> = Record<string, T>;
 
 /**
- * A type which recursively remaps _all_ properties of an object (including optional ones) to a new
- * type `V`.
- *
- * @example
- * ```ts
- * interface A {
- *   a: number;
- *   b: unknown[];
- *   c: {
- *     d: T;
- *     e: {
- *       f: number;
- *     }
- *   }
- * }
- *
- * const remapped: Remap<A, string> = {
- *   a: "these",
- *   b: "properties",
- *   c: {
- *     d: "have been",
- *     e: {
- *       f: "remapped"
- *     }
- *   }
- * }
- * ```
- */
-export type Remap<T extends object, V, E extends (number | string | symbol)[] = never> = {
-    [K in keyof Required<T>]: Required<T>[K] extends object // shortcuts simple types
-        ? K extends ArrayElementType<E> // shortcuts excluded properties
-            ? V
-            : Required<T>[K] extends unknown[] // shortcuts array types
-              ? V
-              : string extends keyof Required<T>[K] // shortcuts indexed types
-                ? V
-                : Remap<Required<T>[K], V, E>
-        : V;
-};
-
-/**
  * Represents a value that may be wrapped in a callback.
  */
 export type MaybeFunction<P extends unknown[], T> = ((...args: P) => Promise<T> | T) | T;
-
-// See: https://stackoverflow.com/a/51399781
-type ArrayElementType<ArrayType extends readonly unknown[]> =
-    ArrayType extends readonly (infer ElementType)[] ? ElementType : never;

--- a/test/integration/iterations-using-describe/iterations-using-describe.spec.ts
+++ b/test/integration/iterations-using-describe/iterations-using-describe.spec.ts
@@ -55,7 +55,7 @@ describe(relative(cwd(), __filename), { timeout: 180000 }, async () => {
                     testIssueIds: [searchResult[1].id],
                 });
                 assert.strictEqual(testResults.length, 1);
-                assert.deepStrictEqual(testResults[0].status, { name: "PASSED" });
+                assert.deepStrictEqual(testResults[0].status, { name: "FAILED" });
                 assert.deepStrictEqual(testResults[0].test, {
                     jira: {
                         key: test.linkedTest,
@@ -108,7 +108,7 @@ describe(relative(cwd(), __filename), { timeout: 180000 }, async () => {
                 const testRun = await getIntegrationClient("xray", test.service).getTestRun(
                     testExecution[0].id
                 );
-                assert.deepStrictEqual(testRun.status, "CUSTOM_PASS2");
+                assert.deepStrictEqual(testRun.status, "FAIL");
                 assert.deepStrictEqual(testRun.testKey, test.linkedTest);
                 assert.strictEqual(testRun.evidences.length, 2);
                 assert.strictEqual(
@@ -121,6 +121,7 @@ describe(relative(cwd(), __filename), { timeout: 180000 }, async () => {
                 );
                 assert.strictEqual(testRun.iterations.length, 2);
                 // Workaround because of configured status automations for which I don't have permission.
+                // Would be "FAIL" normally.
                 assert.strictEqual(testRun.iterations[0].status, "TODO");
                 assert.deepStrictEqual(testRun.iterations[0].parameters, [
                     {
@@ -129,6 +130,7 @@ describe(relative(cwd(), __filename), { timeout: 180000 }, async () => {
                     },
                 ]);
                 // Workaround because of configured status automations for which I don't have permission.
+                // Would be "PASS" normally.
                 assert.deepStrictEqual(testRun.iterations[1].status, "TODO");
                 assert.deepStrictEqual(testRun.iterations[1].parameters, [
                     {

--- a/test/integration/iterations-using-describe/server/cypress.config.js
+++ b/test/integration/iterations-using-describe/server/cypress.config.js
@@ -17,13 +17,6 @@ module.exports = defineConfig({
                     },
                     url: "https://example.org",
                 },
-                xray: {
-                    status: {
-                        // Workaround because of configured status automations for which I don't have permission.
-                        failed: "EXECUTING",
-                        passed: "CUSTOM_PASS2",
-                    },
-                },
             });
             return config;
         },

--- a/test/resources/iteratedResult.json
+++ b/test/resources/iteratedResult.json
@@ -1,0 +1,616 @@
+{
+    "status": "finished",
+    "startedTestsAt": "2024-12-20T23:16:53.026Z",
+    "endedTestsAt": "2024-12-20T23:16:54.147Z",
+    "totalDuration": 1121,
+    "totalSuites": 1,
+    "totalTests": 2,
+    "totalPassed": 2,
+    "totalPending": 0,
+    "totalFailed": 0,
+    "totalSkipped": 0,
+    "runs": [
+        {
+            "stats": {
+                "suites": 1,
+                "tests": 2,
+                "passes": 2,
+                "pending": 0,
+                "skipped": 0,
+                "failures": 0,
+                "duration": 1121,
+                "startedAt": "2024-12-20T23:16:53.026Z",
+                "endedAt": "2024-12-20T23:16:54.147Z"
+            },
+            "reporter": "spec",
+            "reporterStats": {
+                "suites": 1,
+                "tests": 2,
+                "passes": 2,
+                "pending": 0,
+                "failures": 0,
+                "start": "2024-12-20T23:16:53.029Z",
+                "end": "2024-12-20T23:16:54.152Z",
+                "duration": 1123
+            },
+            "hooks": [],
+            "tests": [
+                {
+                    "title": ["CYP-237 Test Suite Name", "Test Method Name 1"],
+                    "state": "passed",
+                    "body": "() => {\n    cy.visit(\"/\");\n    if (Cypress.currentRetry < 2) {\n      expect(true).to.eq(false);\n    } else {\n      expect(true).to.eq(true);\n    }\n  }",
+                    "displayError": null,
+                    "attempts": [
+                        {
+                            "state": "failed",
+                            "error": {
+                                "name": "AssertionError",
+                                "message": "expected true to equal false",
+                                "stack": "    at Context.eval (webpack://integration-test/./spec.cy.js:5:28)",
+                                "codeFrame": {
+                                    "line": 5,
+                                    "column": 29,
+                                    "originalFile": "spec.cy.js",
+                                    "relativeFile": "test/integration/iterations-using-describe/server/spec.cy.js",
+                                    "absoluteFile": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/spec.cy.js",
+                                    "frame": "  3 |         cy.visit(\"/\");\n  4 |         if (Cypress.currentRetry < 2) {\n> 5 |             expect(true).to.eq(false);\n    |                             ^\n  6 |         } else {\n  7 |             expect(true).to.eq(true);\n  8 |         }",
+                                    "language": "js"
+                                }
+                            },
+                            "videoTimestamp": 4234,
+                            "duration": 326,
+                            "startedAt": "2024-12-20T23:16:53.034Z",
+                            "screenshots": [
+                                {
+                                    "name": null,
+                                    "takenAt": "2024-12-20T23:16:53.096Z",
+                                    "path": "./test/resources/small CYP-237.png",
+                                    "height": 720,
+                                    "width": 1280
+                                }
+                            ]
+                        },
+                        {
+                            "state": "failed",
+                            "error": {
+                                "name": "AssertionError",
+                                "message": "expected true to equal false",
+                                "stack": "    at Context.eval (webpack://integration-test/./spec.cy.js:5:28)",
+                                "codeFrame": {
+                                    "line": 5,
+                                    "column": 29,
+                                    "originalFile": "spec.cy.js",
+                                    "relativeFile": "test/integration/iterations-using-describe/server/spec.cy.js",
+                                    "absoluteFile": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/spec.cy.js",
+                                    "frame": "  3 |         cy.visit(\"/\");\n  4 |         if (Cypress.currentRetry < 2) {\n> 5 |             expect(true).to.eq(false);\n    |                             ^\n  6 |         } else {\n  7 |             expect(true).to.eq(true);\n  8 |         }",
+                                    "language": "js"
+                                }
+                            },
+                            "videoTimestamp": 4592,
+                            "duration": 531,
+                            "startedAt": "2024-12-20T23:16:53.392Z",
+                            "screenshots": [
+                                {
+                                    "name": null,
+                                    "takenAt": "2024-12-20T23:16:53.435Z",
+                                    "path": "./test/resources/small CYP-237.png",
+                                    "height": 720,
+                                    "width": 1280
+                                }
+                            ]
+                        },
+                        {
+                            "state": "passed",
+                            "error": null,
+                            "videoTimestamp": 5139,
+                            "duration": 143,
+                            "startedAt": "2024-12-20T23:16:53.939Z",
+                            "screenshots": []
+                        }
+                    ]
+                },
+                {
+                    "title": ["CYP-237 Test Suite Name", "Test Method Name 2"],
+                    "state": "passed",
+                    "body": "() => {\n    cy.visit(\"/\");\n    expect(true).to.eq(true);\n  }",
+                    "displayError": null,
+                    "attempts": [
+                        {
+                            "state": "passed",
+                            "error": null,
+                            "videoTimestamp": 5286,
+                            "duration": 59,
+                            "startedAt": "2024-12-20T23:16:54.086Z",
+                            "screenshots": []
+                        }
+                    ]
+                }
+            ],
+            "error": null,
+            "video": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/videos/spec.cy.js.mp4",
+            "spec": {
+                "fileExtension": ".js",
+                "baseName": "spec.cy.js",
+                "fileName": "spec",
+                "specFileExtension": ".cy.js",
+                "relativeToCommonRoot": "spec.cy.js",
+                "specType": "integration",
+                "name": "spec.cy.js",
+                "relative": "spec.cy.js",
+                "absolute": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/spec.cy.js"
+            },
+            "shouldUploadVideo": true
+        }
+    ],
+    "browserPath": "",
+    "browserName": "electron",
+    "browserVersion": "106.0.5249.51",
+    "osName": "win32",
+    "osVersion": "10.0.19045",
+    "cypressVersion": "12.17.4",
+    "config": {
+        "configFile": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress.config.js",
+        "testingType": "e2e",
+        "chromeWebSecurity": false,
+        "baseUrl": "http://localhost:8080",
+        "setupNodeEvents": "[Function setupNodeEvents]",
+        "specPattern": "**/*.cy.js",
+        "retries": 2,
+        "projectRoot": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server",
+        "projectName": "server",
+        "repoRoot": "/home/user/cypress-xray-plugin",
+        "rawJson": {
+            "chromeWebSecurity": false,
+            "e2e": {
+                "baseUrl": "http://localhost:8080",
+                "setupNodeEvents": "[Function setupNodeEvents]",
+                "specPattern": "**/*.cy.js",
+                "retries": 2
+            },
+            "baseUrl": "http://localhost:8080",
+            "setupNodeEvents": "[Function setupNodeEvents]",
+            "specPattern": "**/*.cy.js",
+            "retries": 2,
+            "projectRoot": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server",
+            "projectName": "server",
+            "repoRoot": "/home/user/cypress-xray-plugin"
+        },
+        "morgan": false,
+        "isTextTerminal": true,
+        "socketId": "gz8yqk9l1d",
+        "report": true,
+        "animationDistanceThreshold": 5,
+        "arch": "x64",
+        "blockHosts": null,
+        "clientCertificates": [],
+        "defaultCommandTimeout": 4000,
+        "downloadsFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/downloads",
+        "execTimeout": 60000,
+        "experimentalCspAllowList": false,
+        "experimentalFetchPolyfill": false,
+        "experimentalInteractiveRunEvents": false,
+        "experimentalRunAllSpecs": false,
+        "experimentalMemoryManagement": false,
+        "experimentalModifyObstructiveThirdPartyCode": false,
+        "experimentalSkipDomainInjection": null,
+        "experimentalOriginDependencies": false,
+        "experimentalSourceRewriting": false,
+        "experimentalSingleTabRunMode": false,
+        "experimentalStudio": false,
+        "experimentalWebKitSupport": false,
+        "fileServerFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server",
+        "fixturesFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/fixtures",
+        "excludeSpecPattern": "*.hot-update.js",
+        "includeShadowDom": false,
+        "keystrokeDelay": 0,
+        "modifyObstructiveCode": true,
+        "numTestsKeptInMemory": 0,
+        "platform": "win32",
+        "pageLoadTimeout": 60000,
+        "port": 56061,
+        "projectId": null,
+        "redirectionLimit": 20,
+        "reporter": "spec",
+        "reporterOptions": null,
+        "requestTimeout": 5000,
+        "resolvedNodePath": "/opt/Node/22.11.0/node",
+        "resolvedNodeVersion": "22.11.0",
+        "responseTimeout": 30000,
+        "screenshotOnRunFailure": true,
+        "screenshotsFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/screenshots",
+        "slowTestThreshold": 10000,
+        "scrollBehavior": "top",
+        "supportFile": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/support/e2e.ts",
+        "supportFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/support",
+        "taskTimeout": 60000,
+        "testIsolation": true,
+        "trashAssetsBeforeRuns": true,
+        "userAgent": null,
+        "video": true,
+        "videoCompression": 32,
+        "videosFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/videos",
+        "videoUploadOnPasses": true,
+        "viewportHeight": 660,
+        "viewportWidth": 1000,
+        "waitForAnimations": true,
+        "watchForFileChanges": false,
+        "additionalIgnorePattern": [],
+        "autoOpen": false,
+        "browsers": [
+            {
+                "name": "chrome",
+                "family": "chromium",
+                "channel": "stable",
+                "displayName": "Chrome",
+                "version": "131.0.6778.205",
+                "path": "/opt/Google/Chrome/Application/chrome",
+                "minSupportedVersion": 64,
+                "majorVersion": "131"
+            },
+            {
+                "name": "firefox",
+                "family": "firefox",
+                "channel": "stable",
+                "displayName": "Firefox",
+                "version": "133.0.3",
+                "path": "/opt/Mozilla Firefox/firefox",
+                "minSupportedVersion": 86,
+                "majorVersion": "133",
+                "warning": "Your project has set the configuration option: `chromeWebSecurity` to `false`.\n\nThis option will not have an effect in Firefox. Tests that rely on web security being disabled will not run as expected."
+            },
+            {
+                "name": "edge",
+                "family": "chromium",
+                "channel": "stable",
+                "displayName": "Edge",
+                "version": "131.0.2903.112",
+                "path": "/opt/Microsoft/Edge/Application/msedge",
+                "minSupportedVersion": 79,
+                "majorVersion": "131"
+            },
+            {
+                "name": "electron",
+                "channel": "stable",
+                "family": "chromium",
+                "displayName": "Electron",
+                "version": "106.0.5249.51",
+                "path": "",
+                "majorVersion": 106
+            }
+        ],
+        "clientRoute": "/__/",
+        "cypressBinaryRoot": "/opt/cache/12.17.4/Cypress/resources/app",
+        "devServerPublicPathRoute": "/__cypress/src",
+        "hosts": null,
+        "isInteractive": true,
+        "namespace": "__cypress",
+        "reporterRoute": "/__cypress/reporter",
+        "socketIoCookie": "__socket",
+        "socketIoRoute": "/__socket",
+        "version": "12.17.4",
+        "cypressEnv": "production",
+        "resolved": {
+            "animationDistanceThreshold": {
+                "value": 5,
+                "from": "default"
+            },
+            "arch": {
+                "value": "x64",
+                "from": "default"
+            },
+            "baseUrl": {
+                "value": "http://localhost:8080",
+                "from": "config"
+            },
+            "blockHosts": {
+                "value": null,
+                "from": "default"
+            },
+            "chromeWebSecurity": {
+                "value": false,
+                "from": "config"
+            },
+            "clientCertificates": {
+                "value": [],
+                "from": "default"
+            },
+            "defaultCommandTimeout": {
+                "value": 4000,
+                "from": "default"
+            },
+            "downloadsFolder": {
+                "value": "cypress/downloads",
+                "from": "default"
+            },
+            "execTimeout": {
+                "value": 60000,
+                "from": "default"
+            },
+            "experimentalCspAllowList": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalFetchPolyfill": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalInteractiveRunEvents": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalRunAllSpecs": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalMemoryManagement": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalModifyObstructiveThirdPartyCode": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalSkipDomainInjection": {
+                "value": null,
+                "from": "default"
+            },
+            "experimentalOriginDependencies": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalSourceRewriting": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalSingleTabRunMode": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalStudio": {
+                "value": false,
+                "from": "default"
+            },
+            "experimentalWebKitSupport": {
+                "value": false,
+                "from": "default"
+            },
+            "fileServerFolder": {
+                "value": "",
+                "from": "default"
+            },
+            "fixturesFolder": {
+                "value": "cypress/fixtures",
+                "from": "default"
+            },
+            "excludeSpecPattern": {
+                "value": "*.hot-update.js",
+                "from": "default"
+            },
+            "includeShadowDom": {
+                "value": false,
+                "from": "default"
+            },
+            "keystrokeDelay": {
+                "value": 0,
+                "from": "default"
+            },
+            "modifyObstructiveCode": {
+                "value": true,
+                "from": "default"
+            },
+            "nodeVersion": {
+                "from": "default"
+            },
+            "numTestsKeptInMemory": {
+                "value": 0,
+                "from": "config"
+            },
+            "platform": {
+                "value": "win32",
+                "from": "default"
+            },
+            "pageLoadTimeout": {
+                "value": 60000,
+                "from": "default"
+            },
+            "port": {
+                "value": null,
+                "from": "default"
+            },
+            "projectId": {
+                "value": null,
+                "from": "default"
+            },
+            "redirectionLimit": {
+                "value": 20,
+                "from": "default"
+            },
+            "reporter": {
+                "value": "spec",
+                "from": "default"
+            },
+            "reporterOptions": {
+                "value": null,
+                "from": "default"
+            },
+            "requestTimeout": {
+                "value": 5000,
+                "from": "default"
+            },
+            "resolvedNodePath": {
+                "value": null,
+                "from": "default"
+            },
+            "resolvedNodeVersion": {
+                "value": null,
+                "from": "default"
+            },
+            "responseTimeout": {
+                "value": 30000,
+                "from": "default"
+            },
+            "retries": {
+                "value": 2,
+                "from": "config"
+            },
+            "screenshotOnRunFailure": {
+                "value": true,
+                "from": "default"
+            },
+            "screenshotsFolder": {
+                "value": "cypress/screenshots",
+                "from": "default"
+            },
+            "slowTestThreshold": {
+                "value": 10000,
+                "from": "default"
+            },
+            "scrollBehavior": {
+                "value": "top",
+                "from": "default"
+            },
+            "supportFile": {
+                "value": "cypress/support/e2e.{js,jsx,ts,tsx}",
+                "from": "default"
+            },
+            "supportFolder": {
+                "value": false,
+                "from": "default"
+            },
+            "taskTimeout": {
+                "value": 60000,
+                "from": "default"
+            },
+            "testIsolation": {
+                "value": true,
+                "from": "default"
+            },
+            "trashAssetsBeforeRuns": {
+                "value": true,
+                "from": "default"
+            },
+            "userAgent": {
+                "value": null,
+                "from": "default"
+            },
+            "video": {
+                "value": true,
+                "from": "default"
+            },
+            "videoCompression": {
+                "value": 32,
+                "from": "default"
+            },
+            "videosFolder": {
+                "value": "cypress/videos",
+                "from": "default"
+            },
+            "videoUploadOnPasses": {
+                "value": true,
+                "from": "default"
+            },
+            "viewportHeight": {
+                "value": 660,
+                "from": "default"
+            },
+            "viewportWidth": {
+                "value": 1000,
+                "from": "default"
+            },
+            "waitForAnimations": {
+                "value": true,
+                "from": "default"
+            },
+            "watchForFileChanges": {
+                "value": false,
+                "from": "config"
+            },
+            "specPattern": {
+                "value": "**/*.cy.js",
+                "from": "config"
+            },
+            "browsers": {
+                "value": [
+                    {
+                        "name": "chrome",
+                        "family": "chromium",
+                        "channel": "stable",
+                        "displayName": "Chrome",
+                        "version": "131.0.6778.205",
+                        "path": "/opt/Google/Chrome/Application/chrome",
+                        "minSupportedVersion": 64,
+                        "majorVersion": "131"
+                    },
+                    {
+                        "name": "firefox",
+                        "family": "firefox",
+                        "channel": "stable",
+                        "displayName": "Firefox",
+                        "version": "133.0.3",
+                        "path": "/opt/Mozilla Firefox/firefox",
+                        "minSupportedVersion": 86,
+                        "majorVersion": "133"
+                    },
+                    {
+                        "name": "edge",
+                        "family": "chromium",
+                        "channel": "stable",
+                        "displayName": "Edge",
+                        "version": "131.0.2903.112",
+                        "path": "/opt/Microsoft/Edge/Application/msedge",
+                        "minSupportedVersion": 79,
+                        "majorVersion": "131"
+                    },
+                    {
+                        "name": "electron",
+                        "channel": "stable",
+                        "family": "chromium",
+                        "displayName": "Electron",
+                        "version": "106.0.5249.51",
+                        "path": "",
+                        "majorVersion": 106,
+                        "isHeadless": true,
+                        "isHeaded": false
+                    }
+                ],
+                "from": "runtime"
+            },
+            "hosts": {
+                "value": null,
+                "from": "default"
+            },
+            "isInteractive": {
+                "value": true,
+                "from": "default"
+            },
+            "configFile": {
+                "value": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress.config.js",
+                "from": "plugin"
+            },
+            "testingType": {
+                "value": "e2e",
+                "from": "plugin"
+            }
+        },
+        "remote": {
+            "origin": "http://localhost:8080",
+            "strategy": "http",
+            "fileServer": null,
+            "domainName": "localhost",
+            "props": {
+                "port": "8080",
+                "protocol": "http:",
+                "subdomain": null,
+                "domain": "",
+                "tld": "localhost"
+            }
+        },
+        "browser": null,
+        "specs": [],
+        "proxyUrl": "http://localhost:56061",
+        "browserUrl": "http://localhost:8080/__/",
+        "reporterUrl": "http://localhost:8080/__cypress/reporter",
+        "proxyServer": "http://localhost:56061",
+        "state": {}
+    }
+}

--- a/test/resources/iteratedResult_13_16_0.json
+++ b/test/resources/iteratedResult_13_16_0.json
@@ -1,0 +1,208 @@
+{
+    "browserName": "electron",
+    "browserPath": "",
+    "browserVersion": "118.0.5993.159",
+    "config": {
+        "configFile": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress.config.js",
+        "testingType": "e2e",
+        "chromeWebSecurity": false,
+        "baseUrl": "http://localhost:8080",
+        "specPattern": "**/*.cy.js",
+        "retries": 2,
+        "projectRoot": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server",
+        "projectName": "server",
+        "isTextTerminal": true,
+        "animationDistanceThreshold": 5,
+        "arch": "x64",
+        "blockHosts": null,
+        "clientCertificates": [],
+        "defaultBrowser": null,
+        "defaultCommandTimeout": 4000,
+        "downloadsFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/downloads",
+        "execTimeout": 60000,
+        "experimentalCspAllowList": false,
+        "experimentalFetchPolyfill": false,
+        "experimentalInteractiveRunEvents": false,
+        "experimentalRunAllSpecs": false,
+        "experimentalMemoryManagement": false,
+        "experimentalModifyObstructiveThirdPartyCode": false,
+        "experimentalSkipDomainInjection": null,
+        "experimentalJustInTimeCompile": false,
+        "experimentalOriginDependencies": false,
+        "experimentalSourceRewriting": false,
+        "experimentalSingleTabRunMode": false,
+        "experimentalStudio": false,
+        "experimentalWebKitSupport": false,
+        "fileServerFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server",
+        "fixturesFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/fixtures",
+        "excludeSpecPattern": "*.hot-update.js",
+        "includeShadowDom": false,
+        "keystrokeDelay": 0,
+        "modifyObstructiveCode": true,
+        "numTestsKeptInMemory": 0,
+        "platform": "win32",
+        "pageLoadTimeout": 60000,
+        "port": 56173,
+        "projectId": null,
+        "redirectionLimit": 20,
+        "reporter": "spec",
+        "reporterOptions": null,
+        "requestTimeout": 5000,
+        "resolvedNodePath": "/opt/Node/22.11.0/node",
+        "resolvedNodeVersion": "22.11.0",
+        "responseTimeout": 30000,
+        "screenshotOnRunFailure": true,
+        "screenshotsFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/screenshots",
+        "slowTestThreshold": 10000,
+        "scrollBehavior": "top",
+        "supportFile": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/support/e2e.ts",
+        "taskTimeout": 60000,
+        "testIsolation": true,
+        "trashAssetsBeforeRuns": true,
+        "userAgent": null,
+        "video": false,
+        "videoCompression": false,
+        "videosFolder": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/cypress/videos",
+        "viewportHeight": 660,
+        "viewportWidth": 1000,
+        "waitForAnimations": true,
+        "watchForFileChanges": false,
+        "browsers": [
+            {
+                "channel": "stable",
+                "displayName": "Chrome",
+                "family": "chromium",
+                "majorVersion": "131",
+                "name": "chrome",
+                "path": "/opt/Google/Chrome/Application/chrome",
+                "version": "131.0.6778.205"
+            },
+            {
+                "channel": "stable",
+                "displayName": "Firefox",
+                "family": "firefox",
+                "majorVersion": "133",
+                "name": "firefox",
+                "path": "/opt/Mozilla Firefox/firefox",
+                "version": "133.0.3"
+            },
+            {
+                "channel": "stable",
+                "displayName": "Edge",
+                "family": "chromium",
+                "majorVersion": "131",
+                "name": "edge",
+                "path": "/opt/Microsoft/Edge/Application/msedge",
+                "version": "131.0.2903.112"
+            },
+            {
+                "channel": "stable",
+                "displayName": "Electron",
+                "family": "chromium",
+                "majorVersion": 118,
+                "name": "electron",
+                "path": "",
+                "version": "118.0.5993.159"
+            }
+        ],
+        "cypressBinaryRoot": "/opt/cache/13.16.0/Cypress/resources/app",
+        "hosts": null,
+        "isInteractive": true,
+        "version": "13.16.0",
+        "browser": null,
+        "cypressInternalEnv": "production"
+    },
+    "cypressVersion": "13.16.0",
+    "endedTestsAt": "2024-12-20T23:19:16.097Z",
+    "osName": "win32",
+    "osVersion": "10.0.19045",
+    "runs": [
+        {
+            "error": null,
+            "reporter": "spec",
+            "reporterStats": {
+                "suites": 1,
+                "tests": 2,
+                "passes": 2,
+                "pending": 0,
+                "failures": 0,
+                "start": "2024-12-20T23:19:14.975Z",
+                "end": "2024-12-20T23:19:16.101Z",
+                "duration": 1126
+            },
+            "screenshots": [
+                {
+                    "height": 720,
+                    "name": null,
+                    "path": "./test/resources/small CYP-237.png",
+                    "takenAt": "2024-12-20T23:19:15.012Z",
+                    "width": 1280
+                },
+                {
+                    "height": 720,
+                    "name": null,
+                    "path": "./test/resources/small CYP-237.png",
+                    "takenAt": "2024-12-20T23:19:15.355Z",
+                    "width": 1280
+                }
+            ],
+            "spec": {
+                "absolute": "/home/user/cypress-xray-plugin/test/integration/iterations-using-describe/server/spec.cy.js",
+                "fileExtension": ".js",
+                "fileName": "spec",
+                "name": "spec.cy.js",
+                "relative": "spec.cy.js"
+            },
+            "stats": {
+                "duration": 1128,
+                "endedAt": "2024-12-20T23:19:16.097Z",
+                "failures": 0,
+                "passes": 2,
+                "pending": 0,
+                "skipped": 0,
+                "startedAt": "2024-12-20T23:19:14.969Z",
+                "suites": 1,
+                "tests": 2
+            },
+            "tests": [
+                {
+                    "attempts": [
+                        {
+                            "state": "failed"
+                        },
+                        {
+                            "state": "failed"
+                        },
+                        {
+                            "state": "passed"
+                        }
+                    ],
+                    "displayError": null,
+                    "duration": 1003,
+                    "state": "passed",
+                    "title": ["CYP-237 Test Suite Name", "Test Method Name 1"]
+                },
+                {
+                    "attempts": [
+                        {
+                            "state": "passed"
+                        }
+                    ],
+                    "displayError": null,
+                    "duration": 52,
+                    "state": "passed",
+                    "title": ["CYP-237 Test Suite Name", "Test Method Name 2"]
+                }
+            ],
+            "video": null
+        }
+    ],
+    "startedTestsAt": "2024-12-20T23:19:14.969Z",
+    "totalDuration": 1128,
+    "totalFailed": 0,
+    "totalPassed": 2,
+    "totalPending": 0,
+    "totalSkipped": 0,
+    "totalSuites": 1,
+    "totalTests": 2
+}


### PR DESCRIPTION
Different users are going to request different ways to compute the Xray status of data-driven/iterated tests. This option can be used for that.