### PR TITLE
Add `logger` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Features include:
     - reuse existing test execution and test plan issues
 - CI/CD ready
     - no hardcoded credentials
-    - every option customizable in CLI
 - Cucumber integration
     - synchronization/upload of step definitions to Xray
     - results upload as described above

--- a/src/client/authentication/credentials.spec.ts
+++ b/src/client/authentication/credentials.spec.ts
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import { relative } from "node:path";
 import { cwd } from "node:process";
 import { beforeEach, describe, it } from "node:test";
-import { Level, LOG } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import { AxiosRestClient } from "../https/requests";
 import { JwtCredentials } from "./credentials";
 
@@ -103,7 +103,7 @@ describe(relative(cwd(), __filename), async () => {
                     message: "Failed to authenticate",
                 });
                 assert.deepEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to authenticate: Request failed with status code 404",
                 ]);
             });

--- a/src/client/authentication/credentials.ts
+++ b/src/client/authentication/credentials.ts
@@ -1,5 +1,5 @@
 import { encode } from "../../util/base64";
-import { LOG, Level } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import type { AxiosRestClient } from "../https/requests";
 import { loggedRequest } from "../util";
 
@@ -111,7 +111,7 @@ export class JwtCredentials implements HttpCredentials {
 
     @loggedRequest({ purpose: "authenticate" })
     private async fetchToken(): Promise<string> {
-        LOG.message(Level.INFO, `Authenticating to: ${this.authenticationUrl}...`);
+        LOG.message("info", `Authenticating to: ${this.authenticationUrl}...`);
         const response = await this.httpClient.post<string>(this.authenticationUrl, {
             ["client_id"]: this.clientId,
             ["client_secret"]: this.clientSecret,
@@ -119,7 +119,7 @@ export class JwtCredentials implements HttpCredentials {
         // A JWT token is expected: https://stackoverflow.com/a/74325712
         const jwtRegex = /^[A-Za-z0-9_-]{2,}(?:\.[A-Za-z0-9_-]{2,}){2}$/;
         if (jwtRegex.test(response.data)) {
-            LOG.message(Level.DEBUG, "Authentication successful");
+            LOG.message("debug", "Authentication successful");
             return response.data;
         } else {
             throw new Error("Expected to receive a JWT token, but did not");

--- a/src/client/https/requests.spec.ts
+++ b/src/client/https/requests.spec.ts
@@ -7,7 +7,7 @@ import { cwd } from "node:process";
 import { beforeEach, describe, it } from "node:test";
 import { LOCAL_SERVER } from "../../../test/server";
 import type { Logger } from "../../util/logging";
-import { Level, LOG } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import { AxiosRestClient } from "./requests";
 
 describe(relative(cwd(), __filename), async () => {
@@ -50,11 +50,11 @@ describe(relative(cwd(), __filename), async () => {
             await assert.rejects(client.get("https://localhost:1234"));
             assert.strictEqual(message.mock.callCount(), 2);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.DEBUG,
+                "debug",
                 "Request:  request.json",
             ]);
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.DEBUG,
+                "debug",
                 "Response: response.json",
             ]);
 
@@ -129,11 +129,11 @@ describe(relative(cwd(), __filename), async () => {
             await promise;
 
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Waiting for http://localhost:1234 to respond... (10 seconds)",
             ]);
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.INFO,
+                "info",
                 "Waiting for http://localhost:1234 to respond... (20 seconds)",
             ]);
         });
@@ -180,11 +180,11 @@ describe(relative(cwd(), __filename), async () => {
             );
             assert.strictEqual(message.mock.callCount(), 2);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.DEBUG,
+                "debug",
                 "Request:  request.json",
             ]);
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.DEBUG,
+                "debug",
                 "Response: response.json",
             ]);
 
@@ -263,11 +263,11 @@ describe(relative(cwd(), __filename), async () => {
             await promise;
 
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Waiting for http://localhost:1234 to respond... (10 seconds)",
             ]);
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.INFO,
+                "info",
                 "Waiting for http://localhost:1234 to respond... (20 seconds)",
             ]);
         });
@@ -314,11 +314,11 @@ describe(relative(cwd(), __filename), async () => {
             );
             assert.strictEqual(message.mock.callCount(), 2);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.DEBUG,
+                "debug",
                 "Request:  request.json",
             ]);
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.DEBUG,
+                "debug",
                 "Response: response.json",
             ]);
 
@@ -398,11 +398,11 @@ describe(relative(cwd(), __filename), async () => {
             await promise;
 
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Waiting for http://localhost:1234 to respond... (10 seconds)",
             ]);
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.INFO,
+                "info",
                 "Waiting for http://localhost:1234 to respond... (20 seconds)",
             ]);
         });

--- a/src/client/https/requests.ts
+++ b/src/client/https/requests.ts
@@ -8,7 +8,7 @@ import {
 } from "axios";
 import FormData from "form-data";
 import { normalizedFilename } from "../../util/files";
-import { LOG, Level } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import { unknownToString } from "../../util/string";
 import { startInterval } from "../../util/time";
 
@@ -216,7 +216,7 @@ export class AxiosRestClient {
                     ),
                     filename
                 );
-                LOG.message(Level.DEBUG, `Request:  ${resolvedFilename}`);
+                LOG.message("debug", `Request:  ${resolvedFilename}`);
             });
         } else {
             const resolvedFilename = LOG.logToFile(
@@ -232,7 +232,7 @@ export class AxiosRestClient {
                 ),
                 filename
             );
-            LOG.message(Level.DEBUG, `Request:  ${resolvedFilename}`);
+            LOG.message("debug", `Request:  ${resolvedFilename}`);
         }
     }
 
@@ -261,7 +261,7 @@ export class AxiosRestClient {
             ),
             filename
         );
-        LOG.message(Level.DEBUG, `Response: ${resolvedFilename}`);
+        LOG.message("debug", `Response: ${resolvedFilename}`);
     }
 
     private logError(direction: "inbound" | "outbound", error: unknown): void {
@@ -285,7 +285,7 @@ export class AxiosRestClient {
         )}.json`;
         const resolvedFilename = LOG.logToFile(JSON.stringify(data, null, 2), filename);
         LOG.message(
-            Level.DEBUG,
+            "debug",
             `${direction === "inbound" ? "Response" : "Request"}: ${resolvedFilename}`
         );
     }
@@ -293,7 +293,7 @@ export class AxiosRestClient {
     private startResponseInterval(url: string): ReturnType<typeof setInterval> {
         return startInterval((totalTime: number) => {
             LOG.message(
-                Level.INFO,
+                "info",
                 `Waiting for ${url} to respond... (${(totalTime / 1000).toString()} seconds)`
             );
         });

--- a/src/client/jira/jira-client.spec.ts
+++ b/src/client/jira/jira-client.spec.ts
@@ -9,7 +9,7 @@ import type { IssueTypeDetails } from "../../types/jira/responses/issue-type-det
 import type { SearchResults } from "../../types/jira/responses/search-results";
 import type { User } from "../../types/jira/responses/user";
 import type { Logger } from "../../util/logging";
-import { Level, LOG } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import { BasicAuthCredentials } from "../authentication/credentials";
 import { AxiosRestClient } from "../https/requests";
 import { BaseJiraClient } from "./jira-client";
@@ -136,7 +136,7 @@ describe(relative(cwd(), __filename), async () => {
                 );
                 assert.strictEqual(response, mockedData);
                 assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                    Level.WARNING,
+                    "warning",
                     "File does not exist:",
                     "./test/resources/missingGreetings.txt",
                 ]);
@@ -180,7 +180,7 @@ describe(relative(cwd(), __filename), async () => {
                 );
                 assert.deepStrictEqual(response, []);
                 assert.deepStrictEqual(message.mock.calls[2].arguments, [
-                    Level.WARNING,
+                    "warning",
                     "All files do not exist. Skipping attaching.",
                 ]);
             });
@@ -189,7 +189,7 @@ describe(relative(cwd(), __filename), async () => {
                 const message = context.mock.method(LOG, "message", context.mock.fn());
                 assert.deepStrictEqual(await client.addAttachment("CYP-123"), []);
                 assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                    Level.WARNING,
+                    "warning",
                     "No files provided to attach to issue CYP-123. Skipping attaching.",
                 ]);
             });
@@ -224,7 +224,7 @@ describe(relative(cwd(), __filename), async () => {
                     { message: "Failed to attach files" }
                 );
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to attach files: Request failed with status code 413",
                 ]);
                 assert.deepStrictEqual(logErrorToFile.mock.calls[0].arguments, [
@@ -305,7 +305,7 @@ describe(relative(cwd(), __filename), async () => {
                     message: "Failed to get issue types",
                 });
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to get issue types: Request failed with status code 409",
                 ]);
                 assert.deepStrictEqual(logErrorToFile.mock.calls[0].arguments, [
@@ -362,7 +362,7 @@ describe(relative(cwd(), __filename), async () => {
                 });
                 await assert.rejects(client.getFields(), { message: "Failed to get fields" });
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to get fields: Request failed with status code 409",
                 ]);
                 assert.deepStrictEqual(logErrorToFile.mock.calls[0].arguments, [
@@ -428,7 +428,7 @@ describe(relative(cwd(), __filename), async () => {
                 });
                 await assert.rejects(client.getMyself(), { message: "Failed to get user details" });
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to get user details: Request failed with status code 409",
                 ]);
                 assert.deepStrictEqual(logErrorToFile.mock.calls[0].arguments, [
@@ -612,7 +612,7 @@ describe(relative(cwd(), __filename), async () => {
                 });
                 await assert.rejects(client.search({}), { message: "Failed to search issues" });
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to search issues: Request failed with status code 401",
                 ]);
                 assert.deepStrictEqual(logErrorToFile.mock.calls[0].arguments, [
@@ -683,7 +683,7 @@ describe(relative(cwd(), __filename), async () => {
                     { message: "Failed to edit issue" }
                 );
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to edit issue: Request failed with status code 400",
                 ]);
                 assert.deepStrictEqual(logErrorToFile.mock.calls[0].arguments, [
@@ -768,7 +768,7 @@ describe(relative(cwd(), __filename), async () => {
                     { message: "Failed to transition issue" }
                 );
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to transition issue: Request failed with status code 404",
                 ]);
                 assert.deepStrictEqual(logErrorToFile.mock.calls[0].arguments, [

--- a/src/client/jira/jira-client.ts
+++ b/src/client/jira/jira-client.ts
@@ -11,7 +11,7 @@ import type { SearchResults } from "../../types/jira/responses/search-results";
 import type { User } from "../../types/jira/responses/user";
 import type { StringMap } from "../../types/util";
 import { dedent } from "../../util/dedent";
-import { LOG, Level } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import { Client } from "../client";
 import { loggedRequest } from "../util";
 
@@ -108,7 +108,7 @@ export class BaseJiraClient extends Client implements JiraClient {
     public async addAttachment(issueIdOrKey: string, ...files: string[]): Promise<Attachment[]> {
         if (files.length === 0) {
             LOG.message(
-                Level.WARNING,
+                "warning",
                 `No files provided to attach to issue ${issueIdOrKey}. Skipping attaching.`
             );
             return [];
@@ -117,7 +117,7 @@ export class BaseJiraClient extends Client implements JiraClient {
         let filesIncluded = 0;
         files.forEach((file: string) => {
             if (!fs.existsSync(file)) {
-                LOG.message(Level.WARNING, "File does not exist:", file);
+                LOG.message("warning", "File does not exist:", file);
                 return;
             }
             filesIncluded++;
@@ -126,12 +126,12 @@ export class BaseJiraClient extends Client implements JiraClient {
         });
 
         if (filesIncluded === 0) {
-            LOG.message(Level.WARNING, "All files do not exist. Skipping attaching.");
+            LOG.message("warning", "All files do not exist. Skipping attaching.");
             return [];
         }
 
         const header = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Attaching files:", ...files);
+        LOG.message("debug", "Attaching files:", ...files);
         const response: AxiosResponse<Attachment[]> = await this.httpClient.post(
             `${this.apiBaseUrl}/rest/api/latest/issue/${issueIdOrKey}/attachments`,
             form,
@@ -144,7 +144,7 @@ export class BaseJiraClient extends Client implements JiraClient {
             }
         );
         LOG.message(
-            Level.DEBUG,
+            "debug",
             dedent(`
                 Successfully attached the following files to issue ${issueIdOrKey}:
 
@@ -157,7 +157,7 @@ export class BaseJiraClient extends Client implements JiraClient {
     @loggedRequest({ purpose: "get issue types" })
     public async getIssueTypes(): Promise<IssueTypeDetails[]> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Getting issue types...");
+        LOG.message("debug", "Getting issue types...");
         const response: AxiosResponse<IssueTypeDetails[]> = await this.httpClient.get(
             `${this.apiBaseUrl}/rest/api/latest/issuetype`,
             {
@@ -167,11 +167,11 @@ export class BaseJiraClient extends Client implements JiraClient {
             }
         );
         LOG.message(
-            Level.DEBUG,
+            "debug",
             `Successfully retrieved data for ${response.data.length.toString()} issue types.`
         );
         LOG.message(
-            Level.DEBUG,
+            "debug",
             dedent(`
                 Received data for issue types:
 
@@ -196,7 +196,7 @@ export class BaseJiraClient extends Client implements JiraClient {
     @loggedRequest({ purpose: "get fields" })
     public async getFields(): Promise<FieldDetail[]> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Getting fields...");
+        LOG.message("debug", "Getting fields...");
         const response: AxiosResponse<FieldDetail[]> = await this.httpClient.get(
             `${this.apiBaseUrl}/rest/api/latest/field`,
             {
@@ -206,11 +206,11 @@ export class BaseJiraClient extends Client implements JiraClient {
             }
         );
         LOG.message(
-            Level.DEBUG,
+            "debug",
             `Successfully retrieved data for ${response.data.length.toString()} fields.`
         );
         LOG.message(
-            Level.DEBUG,
+            "debug",
             dedent(`
                 Received data for fields:
 
@@ -223,7 +223,7 @@ export class BaseJiraClient extends Client implements JiraClient {
     @loggedRequest({ purpose: "get user details" })
     public async getMyself(): Promise<User> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Getting user details...");
+        LOG.message("debug", "Getting user details...");
         const response: AxiosResponse<User> = await this.httpClient.get(
             `${this.apiBaseUrl}/rest/api/latest/myself`,
             {
@@ -232,14 +232,14 @@ export class BaseJiraClient extends Client implements JiraClient {
                 },
             }
         );
-        LOG.message(Level.DEBUG, "Successfully retrieved user details.");
+        LOG.message("debug", "Successfully retrieved user details.");
         return response.data;
     }
 
     @loggedRequest({ purpose: "search issues" })
     public async search(request: SearchRequest): Promise<Issue[]> {
         const header = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Searching issues...");
+        LOG.message("debug", "Searching issues...");
         let total = 0;
         let startAt = request.startAt ?? 0;
         const results: StringMap<Issue> = {};
@@ -270,14 +270,14 @@ export class BaseJiraClient extends Client implements JiraClient {
                 }
             }
         } while (startAt && startAt < total);
-        LOG.message(Level.DEBUG, `Found ${total.toString()} issues`);
+        LOG.message("debug", `Found ${total.toString()} issues`);
         return Object.values(results);
     }
 
     @loggedRequest({ purpose: "edit issue" })
     public async editIssue(issueIdOrKey: string, issueUpdateData: IssueUpdate): Promise<string> {
         const header = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Editing issue...");
+        LOG.message("debug", "Editing issue...");
         await this.httpClient.put(
             `${this.apiBaseUrl}/rest/api/latest/issue/${issueIdOrKey}`,
             issueUpdateData,
@@ -287,7 +287,7 @@ export class BaseJiraClient extends Client implements JiraClient {
                 },
             }
         );
-        LOG.message(Level.DEBUG, `Successfully edited issue: ${issueIdOrKey}`);
+        LOG.message("debug", `Successfully edited issue: ${issueIdOrKey}`);
         return issueIdOrKey;
     }
 
@@ -297,7 +297,7 @@ export class BaseJiraClient extends Client implements JiraClient {
         issueUpdateData: IssueUpdate
     ): Promise<void> {
         const header = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Transitioning issue...");
+        LOG.message("debug", "Transitioning issue...");
         await this.httpClient.post(
             `${this.apiBaseUrl}/rest/api/latest/issue/${issueIdOrKey}/transitions`,
             issueUpdateData,
@@ -307,6 +307,6 @@ export class BaseJiraClient extends Client implements JiraClient {
                 },
             }
         );
-        LOG.message(Level.DEBUG, `Successfully transitioned issue: ${issueIdOrKey}`);
+        LOG.message("debug", `Successfully transitioned issue: ${issueIdOrKey}`);
     }
 }

--- a/src/client/util.ts
+++ b/src/client/util.ts
@@ -1,5 +1,5 @@
 import { errorMessage, LoggedError } from "../util/errors";
-import { Level, LOG } from "../util/logging";
+import { LOG } from "../util/logging";
 
 /**
  * Decorates the method with an error handler which automatically logs errors and rethrows
@@ -33,7 +33,7 @@ export function loggedRequest(parameters: {
             try {
                 return await target.call(this, ...args);
             } catch (error: unknown) {
-                LOG.message(Level.ERROR, `Failed to ${parameters.purpose}: ${errorMessage(error)}`);
+                LOG.message("error", `Failed to ${parameters.purpose}: ${errorMessage(error)}`);
                 LOG.logErrorToFile(error, `${methodName}Error`);
                 throw new LoggedError(`Failed to ${parameters.purpose}`);
             }

--- a/src/client/xray/xray-client-cloud.spec.ts
+++ b/src/client/xray/xray-client-cloud.spec.ts
@@ -12,7 +12,7 @@ import type {
 } from "../../types/xray/requests/import-execution-multipart-info";
 import type { GetTestsResponse } from "../../types/xray/responses/graphql/get-tests";
 import { dedent } from "../../util/dedent";
-import { Level, LOG } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import { JwtCredentials } from "../authentication/credentials";
 import { AxiosRestClient } from "../https/requests";
 import { XrayClientCloud } from "./xray-client-cloud";
@@ -186,7 +186,7 @@ describe(relative(cwd(), __filename), async () => {
 
                 assert.strictEqual(message.mock.callCount(), 2);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to import Cypress results: Request failed with status code 400",
                 ]);
                 assert.strictEqual(logErrorToFile.mock.callCount(), 1);
@@ -317,7 +317,7 @@ describe(relative(cwd(), __filename), async () => {
                 );
                 assert.strictEqual(message.mock.callCount(), 2);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to import Cypress results: Request failed with status code 400",
                 ]);
                 assert.strictEqual(logErrorToFile.mock.callCount(), 1);
@@ -450,7 +450,7 @@ describe(relative(cwd(), __filename), async () => {
                 );
                 assert.strictEqual(message.mock.callCount(), 2);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to import Cucumber results: Request failed with status code 400",
                 ]);
                 assert.strictEqual(logErrorToFile.mock.callCount(), 1);
@@ -597,7 +597,7 @@ describe(relative(cwd(), __filename), async () => {
                 });
                 assert.strictEqual(message.mock.callCount(), 3);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.DEBUG,
+                    "debug",
                     dedent(`
                         Encountered some errors during feature file import:
                         - Error in file taggedPrefixCorrect.feature: Precondition with key CYP-222 was not found!
@@ -647,7 +647,7 @@ describe(relative(cwd(), __filename), async () => {
 
                 assert.strictEqual(message.mock.callCount(), 2);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.DEBUG,
+                    "debug",
                     dedent(`
                         Encountered some errors during feature file import:
                         - Error in file taggedPrefixCorrect.feature: Precondition with key CYP-222 was not found!
@@ -694,7 +694,7 @@ describe(relative(cwd(), __filename), async () => {
 
                 assert.strictEqual(message.mock.callCount(), 2);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         Failed to import Cucumber features: Request failed with status code 400
 
@@ -734,7 +734,7 @@ describe(relative(cwd(), __filename), async () => {
 
                 assert.strictEqual(message.mock.callCount(), 2);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to import Cucumber features: Connection timeout",
                 ]);
                 assert.strictEqual(logErrorToFile.mock.callCount(), 1);
@@ -995,7 +995,7 @@ describe(relative(cwd(), __filename), async () => {
 
                 assert.strictEqual(message.mock.callCount(), 2);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to get test types: Request failed with status code 400",
                 ]);
                 assert.strictEqual(logErrorToFile.mock.callCount(), 1);
@@ -1394,7 +1394,7 @@ describe(relative(cwd(), __filename), async () => {
                 });
                 assert.strictEqual(message.mock.callCount(), 2);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to get test results: Request failed with status code 400",
                 ]);
                 assert.strictEqual(logErrorToFile.mock.callCount(), 1);

--- a/src/client/xray/xray-client-cloud.ts
+++ b/src/client/xray/xray-client-cloud.ts
@@ -15,7 +15,7 @@ import type {
     IssueDetails,
 } from "../../types/xray/responses/import-feature";
 import { dedent } from "../../util/dedent";
-import { LOG, Level } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import type { JwtCredentials } from "../authentication/credentials";
 import type { AxiosRestClient } from "../https/requests";
 import { loggedRequest } from "../util";
@@ -89,7 +89,7 @@ export class XrayClientCloud
     @loggedRequest({ purpose: "get test results" })
     public async getTestResults(issueId: string): ReturnType<HasTestResults["getTestResults"]> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Retrieving test results...");
+        LOG.message("debug", "Retrieving test results...");
         const tests: Test<{ key: string; summary: string }>[] = [];
         let total = 0;
         let start = 0;
@@ -141,7 +141,7 @@ export class XrayClientCloud
             }
         } while (start && start < total);
         LOG.message(
-            Level.DEBUG,
+            "debug",
             `Successfully retrieved test results for test execution issue: ${issueId}`
         );
         return tests;
@@ -152,7 +152,7 @@ export class XrayClientCloud
         options: Parameters<HasTestRunResults["getTestRunResults"]>[0]
     ): Promise<TestRun<{ key: string }>[]> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Retrieving test run results...");
+        LOG.message("debug", "Retrieving test run results...");
         const runResults: TestRun<{ key: string }>[] = [];
         let total = 0;
         let start = 0;
@@ -215,7 +215,7 @@ export class XrayClientCloud
                 }
             }
         } while (start && start < total);
-        LOG.message(Level.DEBUG, "Successfully retrieved test run results");
+        LOG.message("debug", "Successfully retrieved test run results");
         return runResults;
     }
 
@@ -225,7 +225,7 @@ export class XrayClientCloud
         ...issueKeys: string[]
     ): ReturnType<HasTestTypes["getTestTypes"]> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Retrieving test types...");
+        LOG.message("debug", "Retrieving test types...");
         const types: StringMap<string> = {};
         let total = 0;
         let start = 0;
@@ -274,7 +274,7 @@ export class XrayClientCloud
             }
         } while (start && start < total);
         LOG.message(
-            Level.DEBUG,
+            "debug",
             `Successfully retrieved test types for ${issueKeys.length.toString()} issues.`
         );
         return types;
@@ -362,7 +362,7 @@ export class XrayClientCloud
                 if (cloudResponse.errors.length > 0) {
                     response.errors.push(...cloudResponse.errors);
                     LOG.message(
-                        Level.DEBUG,
+                        "debug",
                         dedent(`
                             Encountered some errors during feature file import:
                             ${cloudResponse.errors.map((error: string) => `- ${error}`).join("\n")}
@@ -375,7 +375,7 @@ export class XrayClientCloud
                     );
                     response.updatedOrCreatedIssues.push(...testKeys);
                     LOG.message(
-                        Level.DEBUG,
+                        "debug",
                         dedent(`
                             Successfully updated or created test issues:
 
@@ -389,7 +389,7 @@ export class XrayClientCloud
                     );
                     response.updatedOrCreatedIssues.push(...preconditionKeys);
                     LOG.message(
-                        Level.DEBUG,
+                        "debug",
                         dedent(`
                             Successfully updated or created precondition issues:
 

--- a/src/client/xray/xray-client-server.spec.ts
+++ b/src/client/xray/xray-client-server.spec.ts
@@ -8,7 +8,7 @@ import type { XrayTestExecutionResults } from "../../types/xray/import-test-exec
 import type { CucumberMultipartFeature } from "../../types/xray/requests/import-execution-cucumber-multipart";
 import type { MultipartInfo } from "../../types/xray/requests/import-execution-multipart-info";
 import { dedent } from "../../util/dedent";
-import { Level, LOG } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import { PatCredentials } from "../authentication/credentials";
 import { AxiosRestClient } from "../https/requests";
 import type { XrayClientServer } from "./xray-client-server";
@@ -461,7 +461,7 @@ describe(relative(cwd(), __filename), async () => {
 
                 assert.strictEqual(message.mock.callCount(), 4);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.DEBUG,
+                    "debug",
                     "Encountered an error during feature file import: Test with key CYP-333 was not found!",
                 ]);
                 assert.deepStrictEqual(response, {
@@ -547,7 +547,7 @@ describe(relative(cwd(), __filename), async () => {
                 });
                 assert.strictEqual(message.mock.callCount(), 2);
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.DEBUG,
+                    "debug",
                     "Encountered an error during feature file import: Test with key CYP-333 was not found!\nTest with key CYP-555 was not found!\nPrecondition with key CYP-222 was not found!",
                 ]);
             });
@@ -586,7 +586,7 @@ describe(relative(cwd(), __filename), async () => {
                     { message: "Feature file import failed" }
                 );
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         Failed to import Cucumber features: Request failed with status code 400
 
@@ -623,7 +623,7 @@ describe(relative(cwd(), __filename), async () => {
                     { message: "Feature file import failed" }
                 );
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     "Failed to import Cucumber features: Connection timeout",
                 ]);
                 assert.strictEqual(logErrorToFile.mock.callCount(), 1);
@@ -745,7 +745,7 @@ describe(relative(cwd(), __filename), async () => {
                     message: "Failed to get test execution",
                 });
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         Failed to get test execution: Request failed with status code 400
                     `),
@@ -816,7 +816,7 @@ describe(relative(cwd(), __filename), async () => {
                     message: "Failed to get Xray license",
                 });
                 assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         Failed to get Xray license: Request failed with status code 400
                     `),

--- a/src/client/xray/xray-client-server.ts
+++ b/src/client/xray/xray-client-server.ts
@@ -13,7 +13,7 @@ import type {
 } from "../../types/xray/responses/import-feature";
 import type { XrayLicenseStatus } from "../../types/xray/responses/license";
 import { dedent } from "../../util/dedent";
-import { LOG, Level } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import type { HttpCredentials } from "../authentication/credentials";
 import type { AxiosRestClient } from "../https/requests";
 import { loggedRequest } from "../util";
@@ -83,7 +83,7 @@ export class ServerClient
         query?: Parameters<XrayClientServer["getTestExecution"]>[1]
     ): Promise<GetTestExecutionResponseServer> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Getting test execution results...");
+        LOG.message("debug", "Getting test execution results...");
         let currentPage = query?.page ?? 1;
         let pagedTests: GetTestExecutionResponseServer = [];
         const allTests: GetTestExecutionResponseServer = [];
@@ -112,7 +112,7 @@ export class ServerClient
     @loggedRequest({ purpose: "get test run" })
     public async getTestRun(id: number): Promise<GetTestRunResponseServer> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Getting test run results...");
+        LOG.message("debug", "Getting test run results...");
         const response: AxiosResponse<GetTestRunResponseServer> = await this.httpClient.get(
             `${this.apiBaseUrl}/api/testrun/${id.toString()}`,
             {
@@ -127,7 +127,7 @@ export class ServerClient
     @loggedRequest({ purpose: "get Xray license" })
     public async getXrayLicense(): Promise<XrayLicenseStatus> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.DEBUG, "Getting Xray license status...");
+        LOG.message("debug", "Getting Xray license status...");
         const licenseResponse: AxiosResponse<XrayLicenseStatus> = await this.httpClient.get(
             `${this.apiBaseUrl}/api/xraylicense`,
             {
@@ -222,7 +222,7 @@ export class ServerClient
                     const issueKeys = serverResponse.map((test: IssueDetails) => test.key);
                     response.updatedOrCreatedIssues.push(...issueKeys);
                     LOG.message(
-                        Level.DEBUG,
+                        "debug",
                         dedent(`
                             Successfully updated or created issues:
 
@@ -235,7 +235,7 @@ export class ServerClient
                 if (serverResponse.message) {
                     response.errors.push(serverResponse.message);
                     LOG.message(
-                        Level.DEBUG,
+                        "debug",
                         `Encountered an error during feature file import: ${serverResponse.message}`
                     );
                 }
@@ -245,7 +245,7 @@ export class ServerClient
                     );
                     response.updatedOrCreatedIssues.push(...testKeys);
                     LOG.message(
-                        Level.DEBUG,
+                        "debug",
                         dedent(`
                             Successfully updated or created test issues:
 
@@ -262,7 +262,7 @@ export class ServerClient
                     );
                     response.updatedOrCreatedIssues.push(...preconditionKeys);
                     LOG.message(
-                        Level.DEBUG,
+                        "debug",
                         dedent(`
                             Successfully updated or created precondition issues:
 

--- a/src/client/xray/xray-client.ts
+++ b/src/client/xray/xray-client.ts
@@ -8,7 +8,7 @@ import type { ImportFeatureResponse } from "../../types/xray/responses/import-fe
 import { dedent } from "../../util/dedent";
 import { LoggedError, errorMessage } from "../../util/errors";
 import { HELP } from "../../util/help";
-import { LOG, Level } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import { Client } from "../client";
 import { loggedRequest } from "../util";
 
@@ -87,7 +87,7 @@ export abstract class AbstractXrayClient<ImportFeatureResponseType, ImportExecut
     @loggedRequest({ purpose: "import Cypress results" })
     public async importExecution(execution: XrayTestExecutionResults): Promise<string> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.INFO, "Importing Cypress execution...");
+        LOG.message("info", "Importing Cypress execution...");
         const response: AxiosResponse<ImportExecutionResponseType> = await this.httpClient.post(
             this.getUrlImportExecution(),
             execution,
@@ -98,7 +98,7 @@ export abstract class AbstractXrayClient<ImportFeatureResponseType, ImportExecut
             }
         );
         const key = this.onResponse("import-execution", response.data);
-        LOG.message(Level.DEBUG, `Successfully uploaded test execution results to ${key}.`);
+        LOG.message("debug", `Successfully uploaded test execution results to ${key}.`);
         return key;
     }
 
@@ -108,7 +108,7 @@ export abstract class AbstractXrayClient<ImportFeatureResponseType, ImportExecut
         info: MultipartInfo
     ): Promise<string> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.INFO, "Importing Cypress execution...");
+        LOG.message("info", "Importing Cypress execution...");
         const formData = this.onRequest("import-execution-multipart", executionResults, info);
         const response: AxiosResponse<ImportExecutionResponseType> = await this.httpClient.post(
             this.getUrlImportExecutionMultipart(),
@@ -121,7 +121,7 @@ export abstract class AbstractXrayClient<ImportFeatureResponseType, ImportExecut
             }
         );
         const key = this.onResponse("import-execution-multipart", response.data);
-        LOG.message(Level.DEBUG, `Successfully uploaded test execution results to ${key}.`);
+        LOG.message("debug", `Successfully uploaded test execution results to ${key}.`);
         return key;
     }
 
@@ -131,7 +131,7 @@ export abstract class AbstractXrayClient<ImportFeatureResponseType, ImportExecut
         cucumberInfo: MultipartInfo
     ): Promise<string> {
         const authorizationHeader = await this.credentials.getAuthorizationHeader();
-        LOG.message(Level.INFO, "Importing Cucumber execution...");
+        LOG.message("info", "Importing Cucumber execution...");
         const formData = this.onRequest(
             "import-execution-cucumber-multipart",
             cucumberJson,
@@ -148,10 +148,7 @@ export abstract class AbstractXrayClient<ImportFeatureResponseType, ImportExecut
             }
         );
         const key = this.onResponse("import-execution-cucumber-multipart", response.data);
-        LOG.message(
-            Level.DEBUG,
-            `Successfully uploaded Cucumber test execution results to ${key}.`
-        );
+        LOG.message("debug", `Successfully uploaded Cucumber test execution results to ${key}.`);
         return key;
     }
 
@@ -165,7 +162,7 @@ export abstract class AbstractXrayClient<ImportFeatureResponseType, ImportExecut
     ): Promise<ImportFeatureResponse> {
         try {
             const authorizationHeader = await this.credentials.getAuthorizationHeader();
-            LOG.message(Level.DEBUG, "Importing Cucumber features...");
+            LOG.message("debug", "Importing Cucumber features...");
             const formData = new FormData();
             formData.append("file", fs.createReadStream(file));
 
@@ -184,7 +181,7 @@ export abstract class AbstractXrayClient<ImportFeatureResponseType, ImportExecut
             LOG.logErrorToFile(error, "importFeatureError");
             if (isAxiosError(error) && error.response?.status === HttpStatusCode.BadRequest) {
                 LOG.message(
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         Failed to import Cucumber features: ${errorMessage(error)}
 
@@ -195,10 +192,7 @@ export abstract class AbstractXrayClient<ImportFeatureResponseType, ImportExecut
                     `)
                 );
             } else {
-                LOG.message(
-                    Level.ERROR,
-                    `Failed to import Cucumber features: ${errorMessage(error)}`
-                );
+                LOG.message("error", `Failed to import Cucumber features: ${errorMessage(error)}`);
             }
             throw new LoggedError("Feature file import failed");
         }

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -24,6 +24,7 @@ import type {
 import { dedent } from "./util/dedent";
 import dependencies from "./util/dependencies";
 import { ExecutableGraph } from "./util/graph/executable-graph";
+import type { Level } from "./util/logging";
 import { CapturingLogger, LOG } from "./util/logging";
 
 describe(relative(cwd(), __filename), async () => {
@@ -376,6 +377,18 @@ describe(relative(cwd(), __filename), async () => {
                             }
                         );
                         assert.strictEqual(pluginOptions.logDirectory, "./logs/");
+                    });
+                    await it("logger", () => {
+                        const logger = (level: Level, ...text: string[]) => {
+                            console.log(level, ...text);
+                        };
+                        const pluginOptions = globalContext.initPluginOptions(
+                            {},
+                            {
+                                logger,
+                            }
+                        );
+                        assert.strictEqual(pluginOptions.logger, logger);
                     });
                     await it("normalizeScreenshotNames", () => {
                         const pluginOptions = globalContext.initPluginOptions(

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -24,7 +24,7 @@ import type {
 import { dedent } from "./util/dedent";
 import dependencies from "./util/dependencies";
 import { ExecutableGraph } from "./util/graph/executable-graph";
-import { CapturingLogger, Level, LOG } from "./util/logging";
+import { CapturingLogger, LOG } from "./util/logging";
 
 describe(relative(cwd(), __filename), async () => {
     await describe("the plugin context configuration", async () => {
@@ -1551,11 +1551,11 @@ describe(relative(cwd(), __filename), async () => {
                 assert.strictEqual(get.mock.callCount(), 1);
                 assert.strictEqual(post.mock.callCount(), 1);
                 assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                    Level.INFO,
+                    "info",
                     "Jira username and API token found. Setting up Jira cloud basic auth credentials.",
                 ]);
                 assert.deepStrictEqual(message.mock.calls[4].arguments, [
-                    Level.INFO,
+                    "info",
                     "Xray client ID and client secret found. Setting up Xray cloud JWT credentials.",
                 ]);
             });
@@ -1587,7 +1587,7 @@ describe(relative(cwd(), __filename), async () => {
                     `),
                 });
                 assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                    Level.INFO,
+                    "info",
                     "Jira username and API token found. Setting up Jira cloud basic auth credentials.",
                 ]);
             });
@@ -1640,11 +1640,11 @@ describe(relative(cwd(), __filename), async () => {
                 assert.strictEqual(getJira.mock.callCount(), 1);
                 assert.strictEqual(getXray.mock.callCount(), 1);
                 assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                    Level.INFO,
+                    "info",
                     "Jira PAT found. Setting up Jira server PAT credentials.",
                 ]);
                 assert.deepStrictEqual(message.mock.calls[4].arguments, [
-                    Level.INFO,
+                    "info",
                     "Jira PAT found. Setting up Xray server PAT credentials.",
                 ]);
             });
@@ -1698,11 +1698,11 @@ describe(relative(cwd(), __filename), async () => {
                 assert.strictEqual(getJira.mock.callCount(), 1);
                 assert.strictEqual(getXray.mock.callCount(), 1);
                 assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                    Level.INFO,
+                    "info",
                     "Jira username and password found. Setting up Jira server basic auth credentials.",
                 ]);
                 assert.deepStrictEqual(message.mock.calls[4].arguments, [
-                    Level.INFO,
+                    "info",
                     "Jira username and password found. Setting up Xray server basic auth credentials.",
                 ]);
             });

--- a/src/context.ts
+++ b/src/context.ts
@@ -32,7 +32,7 @@ import { errorMessage } from "./util/errors";
 import type { ExecutableGraph } from "./util/graph/executable-graph";
 import { HELP } from "./util/help";
 import type { Logger } from "./util/logging";
-import { LOG, Level } from "./util/logging";
+import { LOG } from "./util/logging";
 import { asArrayOfStrings, asBoolean, asObject, asString, parse } from "./util/parsing";
 
 export interface EvidenceCollection {
@@ -101,7 +101,7 @@ export class PluginContext implements EvidenceCollection {
 
     public addEvidence(issueKey: string, evidence: XrayEvidenceItem): void {
         this.evidenceCollection.addEvidence(issueKey, evidence);
-        LOG.message(Level.DEBUG, `Added evidence for test ${issueKey}: ${evidence.filename}`);
+        LOG.message("debug", `Added evidence for test ${issueKey}: ${evidence.filename}`);
     }
 
     public getEvidence(issueKey: string): XrayEvidenceItem[] {
@@ -294,7 +294,7 @@ async function initCucumberOptions(
             );
         }
         LOG.message(
-            Level.DEBUG,
+            "debug",
             `Successfully resolved configuration of @badeball/cypress-cucumber-preprocessor package`
         );
         const preprocessorConfiguration = await preprocessor.resolvePreprocessorConfiguration(
@@ -410,7 +410,7 @@ async function initClients(
         ENV_NAMES.authentication.jira.apiToken in env
     ) {
         LOG.message(
-            Level.INFO,
+            "info",
             "Jira username and API token found. Setting up Jira cloud basic auth credentials."
         );
         const credentials = new BasicAuthCredentials(
@@ -423,7 +423,7 @@ async function initClients(
             ENV_NAMES.authentication.xray.clientSecret in env
         ) {
             LOG.message(
-                Level.INFO,
+                "info",
                 "Xray client ID and client secret found. Setting up Xray cloud JWT credentials."
             );
             const xrayCredentials = new JwtCredentials(
@@ -447,12 +447,12 @@ async function initClients(
             `)
         );
     } else if (ENV_NAMES.authentication.jira.apiToken in env) {
-        LOG.message(Level.INFO, "Jira PAT found. Setting up Jira server PAT credentials.");
+        LOG.message("info", "Jira PAT found. Setting up Jira server PAT credentials.");
         const credentials = new PatCredentials(
             env[ENV_NAMES.authentication.jira.apiToken] as string
         );
         const jiraClient = await getJiraClient(jiraOptions.url, credentials, httpClients.jira);
-        LOG.message(Level.INFO, "Jira PAT found. Setting up Xray server PAT credentials.");
+        LOG.message("info", "Jira PAT found. Setting up Xray server PAT credentials.");
         const xrayClient = await getXrayServerClient(
             jiraOptions.url,
             credentials,
@@ -468,7 +468,7 @@ async function initClients(
         ENV_NAMES.authentication.jira.password in env
     ) {
         LOG.message(
-            Level.INFO,
+            "info",
             "Jira username and password found. Setting up Jira server basic auth credentials."
         );
         const credentials = new BasicAuthCredentials(
@@ -477,7 +477,7 @@ async function initClients(
         );
         const jiraClient = await getJiraClient(jiraOptions.url, credentials, httpClients.jira);
         LOG.message(
-            Level.INFO,
+            "info",
             "Jira username and password found. Setting up Xray server basic auth credentials."
         );
         const xrayClient = await getXrayServerClient(
@@ -508,7 +508,7 @@ async function getXrayCloudClient(
     try {
         await credentials.getAuthorizationHeader();
         LOG.message(
-            Level.DEBUG,
+            "debug",
             dedent(`
                 Successfully established communication with: ${credentials.getAuthenticationUrl()}
 
@@ -546,7 +546,7 @@ async function getXrayServerClient(
         if (typeof license === "object" && "active" in license) {
             if (license.active) {
                 LOG.message(
-                    Level.DEBUG,
+                    "debug",
                     dedent(`
                         Successfully established communication with: ${url}
 
@@ -596,7 +596,7 @@ async function getJiraClient(
         const username = userDetails.displayName ?? userDetails.emailAddress ?? userDetails.name;
         if (username) {
             LOG.message(
-                Level.DEBUG,
+                "debug",
                 dedent(`
                     Successfully established communication with: ${url}
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -196,6 +196,7 @@ function initPluginOptions(
         enabled: parse(env, ENV_NAMES.plugin.enabled, asBoolean) ?? options?.enabled ?? true,
         logDirectory:
             parse(env, ENV_NAMES.plugin.logDirectory, asString) ?? options?.logDirectory ?? "logs",
+        logger: options?.logger,
         normalizeScreenshotNames:
             parse(env, ENV_NAMES.plugin.normalizeScreenshotNames, asBoolean) ??
             options?.normalizeScreenshotNames ??

--- a/src/cypress/tasks.spec.ts
+++ b/src/cypress/tasks.spec.ts
@@ -5,7 +5,7 @@ import { describe, it } from "node:test";
 import { getMockedCypress } from "../../test/mocks";
 import { SimpleEvidenceCollection } from "../context";
 import { dedent } from "../util/dedent";
-import { Level, LOG } from "../util/logging";
+import { LOG } from "../util/logging";
 import * as tasks from "./tasks";
 
 describe(path.relative(process.cwd(), __filename), () => {
@@ -226,7 +226,7 @@ describe(path.relative(process.cwd(), __filename), () => {
             });
             assert.strictEqual(addEvidence.mock.callCount(), 0);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Test: This is a test
 
@@ -276,7 +276,7 @@ describe(path.relative(process.cwd(), __filename), () => {
             });
             assert.strictEqual(addEvidence.mock.callCount(), 0);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Test: This is a test
 
@@ -499,7 +499,7 @@ describe(path.relative(process.cwd(), __filename), () => {
             });
             assert.strictEqual(addEvidence.mock.callCount(), 0);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Test: This is a test
 
@@ -564,7 +564,7 @@ describe(path.relative(process.cwd(), __filename), () => {
             });
             assert.strictEqual(addEvidence.mock.callCount(), 0);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Test: This is a test
 

--- a/src/cypress/tasks.ts
+++ b/src/cypress/tasks.ts
@@ -4,7 +4,6 @@ import { encode } from "../util/base64";
 import { dedent } from "../util/dedent";
 import { errorMessage } from "../util/errors";
 import type { Logger } from "../util/logging";
-import { Level } from "../util/logging";
 
 /**
  * All tasks which are available within the plugin.
@@ -160,7 +159,7 @@ export class PluginTaskListener implements TaskListener {
         } catch (error: unknown) {
             if (!this.ignoredTests.has(args.test)) {
                 this.logger.message(
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         Test: ${args.test}
 
@@ -190,7 +189,7 @@ export class PluginTaskListener implements TaskListener {
         } catch (error: unknown) {
             if (!this.ignoredTests.has(args.test)) {
                 this.logger.message(
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         Test: ${args.test}
 

--- a/src/hooks/after/after-run.spec.ts
+++ b/src/hooks/after/after-run.spec.ts
@@ -21,7 +21,7 @@ import type {
     CucumberMultipartFeature,
 } from "../../types/xray/requests/import-execution-cucumber-multipart";
 import { ExecutableGraph } from "../../util/graph/executable-graph";
-import { Level, LOG } from "../../util/logging";
+import { LOG } from "../../util/logging";
 import type { Command } from "../command";
 import { ComputableState } from "../command";
 import { ConstantCommand } from "../util/commands/constant-command";
@@ -1201,7 +1201,7 @@ describe(relative(cwd(), __filename), async () => {
                 assert.strictEqual(graph.size("vertices"), 0);
                 assert.strictEqual(graph.size("edges"), 0);
                 assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                    Level.WARNING,
+                    "warning",
                     "No test execution results to upload, skipping results upload preparations.",
                 ]);
             });

--- a/src/hooks/after/after-run.ts
+++ b/src/hooks/after/after-run.ts
@@ -19,7 +19,6 @@ import type { MultipartInfo } from "../../types/xray/requests/import-execution-m
 import { getOrCall } from "../../util/functions";
 import type { ExecutableGraph } from "../../util/graph/executable-graph";
 import type { Logger } from "../../util/logging";
-import { Level } from "../../util/logging";
 import type { Command } from "../command";
 import { ComputableState } from "../command";
 import type { ConstantCommand } from "../util/commands/constant-command";
@@ -67,7 +66,7 @@ async function addUploadCommands(
     );
     if (!containsCypressTests && !containsCucumberTests) {
         logger.message(
-            Level.WARNING,
+            "warning",
             "No test execution results to upload, skipping results upload preparations."
         );
         return;

--- a/src/hooks/after/commands/conversion/cucumber/convert-cucumber-features-command.spec.ts
+++ b/src/hooks/after/commands/conversion/cucumber/convert-cucumber-features-command.spec.ts
@@ -5,7 +5,7 @@ import { cwd } from "node:process";
 import { describe, it } from "node:test";
 import type { CucumberMultipartFeature } from "../../../../../types/xray/requests/import-execution-cucumber-multipart";
 import { dedent } from "../../../../../util/dedent";
-import { Level, LOG } from "../../../../../util/logging";
+import { LOG } from "../../../../../util/logging";
 import { ConstantCommand } from "../../../../util/commands/constant-command";
 import { ConvertCucumberFeaturesCommand } from "./convert-cucumber-features-command";
 
@@ -445,7 +445,7 @@ describe(relative(cwd(), __filename), async () => {
             const features = await command.compute();
 
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ${resolve(
                         ".",
@@ -525,7 +525,7 @@ describe(relative(cwd(), __filename), async () => {
             const features = await command.compute();
 
             assert.deepStrictEqual(message.mock.calls[3].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ${resolve(".", "test", "resources", "cypress", "e2e", "spec.cy.feature")}
 

--- a/src/hooks/after/commands/conversion/cucumber/convert-cucumber-features-command.ts
+++ b/src/hooks/after/commands/conversion/cucumber/convert-cucumber-features-command.ts
@@ -13,7 +13,6 @@ import type {
 import { dedent } from "../../../../../util/dedent";
 import { errorMessage, missingTestKeyInCucumberScenarioError } from "../../../../../util/errors";
 import type { Logger } from "../../../../../util/logging";
-import { Level } from "../../../../../util/logging";
 import type { Computable } from "../../../../command";
 import { Command } from "../../../../command";
 import { getScenarioTagRegex } from "../../../../preprocessor/commands/parsing/scenario";
@@ -83,7 +82,7 @@ export class ConvertCucumberFeaturesCommand extends Command<
                         1
                     )}: ${element.name.length > 0 ? element.name : "<no name>"}`;
                     this.logger.message(
-                        Level.WARNING,
+                        "warning",
                         dedent(`
                             ${filepath}
 

--- a/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.spec.ts
+++ b/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.spec.ts
@@ -8,7 +8,7 @@ import type { CypressRunResult as CypressRunResult_V12 } from "../../../../../ty
 import type { CypressRunResultType } from "../../../../../types/cypress/cypress";
 import type { InternalCypressXrayPluginOptions } from "../../../../../types/plugin";
 import { dedent } from "../../../../../util/dedent";
-import { Level, LOG } from "../../../../../util/logging";
+import { LOG } from "../../../../../util/logging";
 import { ConstantCommand } from "../../../../util/commands/constant-command";
 import { ConvertCypressTestsCommand } from "./convert-cypress-tests-command";
 
@@ -317,7 +317,7 @@ describe(relative(cwd(), __filename), async () => {
                     },
                 ]);
                 assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         ${join(".", "test", "resources", "small.png")}
 
@@ -508,7 +508,7 @@ describe(relative(cwd(), __filename), async () => {
                     "Failed to convert Cypress tests into Xray tests: No Cypress tests to upload",
             });
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Test: TodoMVC hides footer initially
 
@@ -518,7 +518,7 @@ describe(relative(cwd(), __filename), async () => {
                 `),
             ]);
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Test: TodoMVC adds 2 todos
 

--- a/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.ts
+++ b/src/hooks/after/commands/conversion/cypress/convert-cypress-tests-command.ts
@@ -15,7 +15,6 @@ import { dedent } from "../../../../../util/dedent";
 import { errorMessage } from "../../../../../util/errors";
 import { normalizedFilename } from "../../../../../util/files";
 import type { Logger } from "../../../../../util/logging";
-import { Level } from "../../../../../util/logging";
 import { earliestDate, latestDate, truncateIsoTime } from "../../../../../util/time";
 import type { Computable } from "../../../../command";
 import { Command } from "../../../../command";
@@ -64,7 +63,7 @@ export class ConvertCypressTestsCommand extends Command<[XrayTest, ...XrayTest[]
                 }
             } catch (error: unknown) {
                 this.logger.message(
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         ${convertedTest.spec.filepath}
 
@@ -127,7 +126,7 @@ export class ConvertCypressTestsCommand extends Command<[XrayTest, ...XrayTest[]
         for (const [title, conversion] of conversions) {
             if (conversion.kind === "error") {
                 this.logger.message(
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         Test: ${title}
 
@@ -186,7 +185,7 @@ export class ConvertCypressTestsCommand extends Command<[XrayTest, ...XrayTest[]
                     if (!includedScreenshots.includes(screenshot.path)) {
                         const screenshotName = path.parse(screenshot.path).name;
                         this.logger.message(
-                            Level.WARNING,
+                            "warning",
                             dedent(`
                                 ${screenshot.path}
 

--- a/src/hooks/after/commands/verify-execution-issue-key-command.spec.ts
+++ b/src/hooks/after/commands/verify-execution-issue-key-command.spec.ts
@@ -3,7 +3,7 @@ import { relative } from "node:path";
 import { cwd } from "node:process";
 import { describe, it } from "node:test";
 import { dedent } from "../../../util/dedent";
-import { Level, LOG } from "../../../util/logging";
+import { LOG } from "../../../util/logging";
 import { ConstantCommand } from "../../util/commands/constant-command";
 import { VerifyExecutionIssueKeyCommand } from "./verify-execution-issue-key-command";
 
@@ -39,7 +39,7 @@ describe(relative(cwd(), __filename), async () => {
             );
             await command.compute();
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Cypress execution results were imported to test execution CYP-456, which is different from the configured one: CYP-123
 
@@ -68,7 +68,7 @@ describe(relative(cwd(), __filename), async () => {
             );
             await command.compute();
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Cucumber execution results were imported to test execution CYP-456, which is different from the configured one: CYP-123
 

--- a/src/hooks/after/commands/verify-execution-issue-key-command.ts
+++ b/src/hooks/after/commands/verify-execution-issue-key-command.ts
@@ -2,7 +2,6 @@ import type { IssueTypeDetails } from "../../../types/jira/responses/issue-type-
 import { dedent } from "../../../util/dedent";
 import { HELP } from "../../../util/help";
 import type { Logger } from "../../../util/logging";
-import { Level } from "../../../util/logging";
 import type { Computable } from "../../command";
 import { Command } from "../../command";
 
@@ -32,7 +31,7 @@ export class VerifyExecutionIssueKeyCommand extends Command<string, Parameters> 
             resolvedExecutionIssueKey !== this.parameters.testExecutionIssueKey
         ) {
             this.logger.message(
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ${
                         this.parameters.importType === "cypress" ? "Cypress" : "Cucumber"

--- a/src/hooks/after/commands/verify-results-upload-command.spec.ts
+++ b/src/hooks/after/commands/verify-results-upload-command.spec.ts
@@ -4,7 +4,7 @@ import { cwd } from "node:process";
 import { describe, it } from "node:test";
 import { dedent } from "../../../util/dedent";
 import { SkippedError } from "../../../util/errors";
-import { Level, LOG } from "../../../util/logging";
+import { LOG } from "../../../util/logging";
 import { ConstantCommand } from "../../util/commands/constant-command";
 import { VerifyResultsUploadCommand } from "./verify-results-upload-command";
 
@@ -18,7 +18,7 @@ describe(relative(cwd(), __filename), async () => {
             });
             await command.compute();
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.SUCCESS,
+                "notice",
                 "Uploaded Cypress test results to issue: CYP-123 (http://localhost:1234/browse/CYP-123)",
             ]);
         });
@@ -31,7 +31,7 @@ describe(relative(cwd(), __filename), async () => {
             });
             await command.compute();
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.SUCCESS,
+                "notice",
                 "Uploaded Cucumber test results to issue: CYP-123 (http://localhost:1234/browse/CYP-123)",
             ]);
         });
@@ -44,7 +44,7 @@ describe(relative(cwd(), __filename), async () => {
             });
             await command.compute();
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.SUCCESS,
+                "notice",
                 "Uploaded test results to issue: CYP-123 (http://localhost:1234/browse/CYP-123)",
             ]);
         });

--- a/src/hooks/after/commands/verify-results-upload-command.ts
+++ b/src/hooks/after/commands/verify-results-upload-command.ts
@@ -1,7 +1,6 @@
 import { dedent } from "../../../util/dedent";
 import { SkippedError } from "../../../util/errors";
 import type { Logger } from "../../../util/logging";
-import { Level } from "../../../util/logging";
 import type { Computable } from "../../command";
 import { Command } from "../../command";
 
@@ -43,20 +42,20 @@ export class VerifyResultsUploadCommand extends Command<string, Parameters> {
                 );
             } else {
                 this.logger.message(
-                    Level.SUCCESS,
+                    "notice",
                     `Uploaded test results to issue: ${cypressExecutionIssueKey} (${this.parameters.url}/browse/${cypressExecutionIssueKey})`
                 );
                 return cypressExecutionIssueKey;
             }
         } else if (cypressExecutionIssueKey) {
             this.logger.message(
-                Level.SUCCESS,
+                "notice",
                 `Uploaded Cypress test results to issue: ${cypressExecutionIssueKey} (${this.parameters.url}/browse/${cypressExecutionIssueKey})`
             );
             return cypressExecutionIssueKey;
         } else if (cucumberExecutionIssueKey) {
             this.logger.message(
-                Level.SUCCESS,
+                "notice",
                 `Uploaded Cucumber test results to issue: ${cucumberExecutionIssueKey} (${this.parameters.url}/browse/${cucumberExecutionIssueKey})`
             );
             return cucumberExecutionIssueKey;

--- a/src/hooks/preprocessor/commands/get-labels-to-reset-command.spec.ts
+++ b/src/hooks/preprocessor/commands/get-labels-to-reset-command.spec.ts
@@ -3,7 +3,7 @@ import { relative } from "node:path";
 import { cwd } from "node:process";
 import { describe, it } from "node:test";
 import { dedent } from "../../../util/dedent";
-import { Level, LOG } from "../../../util/logging";
+import { LOG } from "../../../util/logging";
 import { ConstantCommand } from "../../util/commands/constant-command";
 import { GetLabelsToResetCommand } from "./get-labels-to-reset-command";
 
@@ -45,7 +45,7 @@ describe(relative(cwd(), __filename), async () => {
             );
             assert.deepStrictEqual(await command.compute(), {});
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     CYP-123
 
@@ -55,7 +55,7 @@ describe(relative(cwd(), __filename), async () => {
                 `),
             ]);
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     CYP-456
 

--- a/src/hooks/preprocessor/commands/get-labels-to-reset-command.ts
+++ b/src/hooks/preprocessor/commands/get-labels-to-reset-command.ts
@@ -1,7 +1,6 @@
 import type { StringMap } from "../../../types/util";
 import { dedent } from "../../../util/dedent";
 import type { Logger } from "../../../util/logging";
-import { Level } from "../../../util/logging";
 import { unknownToString } from "../../../util/string";
 import type { Computable } from "../../command";
 import { Command } from "../../command";
@@ -27,7 +26,7 @@ export class GetLabelsToResetCommand extends Command<StringMap<string[]>, null> 
         for (const [issueKey, newLabels] of Object.entries(newValues)) {
             if (!(issueKey in oldValues)) {
                 this.logger.message(
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         ${issueKey}
 
@@ -44,7 +43,7 @@ export class GetLabelsToResetCommand extends Command<StringMap<string[]>, null> 
                 newLabels.every((label) => oldLabels.includes(label))
             ) {
                 this.logger.message(
-                    Level.DEBUG,
+                    "debug",
                     dedent(`
                         ${issueKey}
 

--- a/src/hooks/preprocessor/commands/get-summaries-to-reset-command.spec.ts
+++ b/src/hooks/preprocessor/commands/get-summaries-to-reset-command.spec.ts
@@ -3,7 +3,7 @@ import { relative } from "node:path";
 import { cwd } from "node:process";
 import { describe, it } from "node:test";
 import { dedent } from "../../../util/dedent";
-import { Level, LOG } from "../../../util/logging";
+import { LOG } from "../../../util/logging";
 import { ConstantCommand } from "../../util/commands/constant-command";
 import { GetSummariesToResetCommand } from "./get-summaries-to-reset-command";
 
@@ -38,7 +38,7 @@ describe(relative(cwd(), __filename), async () => {
             );
             assert.deepStrictEqual(await command.compute(), {});
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     CYP-123
 

--- a/src/hooks/preprocessor/commands/get-summaries-to-reset-command.ts
+++ b/src/hooks/preprocessor/commands/get-summaries-to-reset-command.ts
@@ -1,7 +1,6 @@
 import type { StringMap } from "../../../types/util";
 import { dedent } from "../../../util/dedent";
 import type { Logger } from "../../../util/logging";
-import { Level } from "../../../util/logging";
 import { unknownToString } from "../../../util/string";
 import type { Computable } from "../../command";
 import { Command } from "../../command";
@@ -27,7 +26,7 @@ export class GetSummariesToResetCommand extends Command<StringMap<string>, null>
         for (const [issueKey, newSummary] of Object.entries(newValues)) {
             if (!(issueKey in oldValues)) {
                 this.logger.message(
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         ${issueKey}
 
@@ -41,7 +40,7 @@ export class GetSummariesToResetCommand extends Command<StringMap<string>, null>
             const oldSummary = oldValues[issueKey];
             if (oldSummary === newSummary) {
                 this.logger.message(
-                    Level.DEBUG,
+                    "debug",
                     dedent(`
                         ${issueKey}
 

--- a/src/hooks/preprocessor/commands/get-updated-issues-command.spec.ts
+++ b/src/hooks/preprocessor/commands/get-updated-issues-command.spec.ts
@@ -3,7 +3,7 @@ import { relative } from "node:path";
 import { cwd } from "node:process";
 import { describe, it } from "node:test";
 import { dedent } from "../../../util/dedent";
-import { Level, LOG } from "../../../util/logging";
+import { LOG } from "../../../util/logging";
 import { ConstantCommand } from "../../util/commands/constant-command";
 import { GetUpdatedIssuesCommand } from "./get-updated-issues-command";
 
@@ -42,7 +42,7 @@ describe(relative(cwd(), __filename), async () => {
         );
         assert.deepStrictEqual(await command.compute(), []);
         assert.deepStrictEqual(message.mock.calls[0].arguments, [
-            Level.WARNING,
+            "warning",
             dedent(`
                 ~/home/test/some.feature
 
@@ -77,7 +77,7 @@ describe(relative(cwd(), __filename), async () => {
         );
         assert.deepStrictEqual(await command.compute(), []);
         assert.deepStrictEqual(message.mock.calls[0].arguments, [
-            Level.WARNING,
+            "warning",
             dedent(`
                 ~/home/test/some.feature
 
@@ -112,7 +112,7 @@ describe(relative(cwd(), __filename), async () => {
         );
         assert.deepStrictEqual(await command.compute(), ["CYP-756"]);
         assert.deepStrictEqual(message.mock.calls[0].arguments, [
-            Level.WARNING,
+            "warning",
             dedent(`
                 ~/home/test/some.feature
 

--- a/src/hooks/preprocessor/commands/get-updated-issues-command.ts
+++ b/src/hooks/preprocessor/commands/get-updated-issues-command.ts
@@ -2,7 +2,6 @@ import type { ImportFeatureResponse } from "../../../types/xray/responses/import
 import { dedent } from "../../../util/dedent";
 import { HELP } from "../../../util/help";
 import type { Logger } from "../../../util/logging";
-import { Level } from "../../../util/logging";
 import { computeOverlap } from "../../../util/set";
 import type { Computable } from "../../command";
 import { Command } from "../../command";
@@ -65,7 +64,7 @@ export class GetUpdatedIssuesCommand extends Command<string[], Parameters> {
                 mismatchLines = mismatchLinesJira.join("\n");
             }
             this.logger.message(
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ${this.parameters.filePath}
 

--- a/src/hooks/preprocessor/commands/parse-feature-file-command.spec.ts
+++ b/src/hooks/preprocessor/commands/parse-feature-file-command.spec.ts
@@ -3,7 +3,7 @@ import { relative } from "node:path";
 import { cwd } from "node:process";
 import { describe, it } from "node:test";
 import { dedent } from "../../../util/dedent";
-import { Level, LOG } from "../../../util/logging";
+import { LOG } from "../../../util/logging";
 import { ParseFeatureFileCommand } from "./parse-feature-file-command";
 
 describe(relative(cwd(), __filename), async () => {
@@ -24,7 +24,7 @@ describe(relative(cwd(), __filename), async () => {
                 `),
             });
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 `Parsing feature file: ./test/resources/features/invalid.feature`,
             ]);
         });

--- a/src/hooks/preprocessor/commands/parse-feature-file-command.ts
+++ b/src/hooks/preprocessor/commands/parse-feature-file-command.ts
@@ -1,7 +1,6 @@
 import type { GherkinDocument } from "@cucumber/messages";
 import { dedent } from "../../../util/dedent";
 import { errorMessage } from "../../../util/errors";
-import { Level } from "../../../util/logging";
 import { Command } from "../../command";
 import { parseFeatureFile } from "./parsing/gherkin";
 
@@ -12,7 +11,7 @@ interface Parameters {
 export class ParseFeatureFileCommand extends Command<GherkinDocument, Parameters> {
     protected computeResult(): GherkinDocument {
         try {
-            this.logger.message(Level.INFO, `Parsing feature file: ${this.parameters.filePath}`);
+            this.logger.message("info", `Parsing feature file: ${this.parameters.filePath}`);
             return parseFeatureFile(this.parameters.filePath);
         } catch (error: unknown) {
             throw new Error(

--- a/src/hooks/util/commands/jira/attach-files-command.spec.ts
+++ b/src/hooks/util/commands/jira/attach-files-command.spec.ts
@@ -7,7 +7,7 @@ import { PatCredentials } from "../../../../client/authentication/credentials";
 import { AxiosRestClient } from "../../../../client/https/requests";
 import type { JiraClient } from "../../../../client/jira/jira-client";
 import { BaseJiraClient } from "../../../../client/jira/jira-client";
-import { Level, LOG } from "../../../../util/logging";
+import { LOG } from "../../../../util/logging";
 import { ConstantCommand } from "../constant-command";
 import { AttachFilesCommand } from "./attach-files-command";
 
@@ -48,7 +48,7 @@ describe(relative(cwd(), __filename), async () => {
                 { filename: "something.mp4", size: 54321 },
             ]);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Attaching files to test execution issue CYP-123",
             ]);
         });

--- a/src/hooks/util/commands/jira/attach-files-command.ts
+++ b/src/hooks/util/commands/jira/attach-files-command.ts
@@ -1,7 +1,6 @@
 import type { JiraClient } from "../../../../client/jira/jira-client";
 import type { Attachment } from "../../../../types/jira/responses/attachment";
 import type { Logger } from "../../../../util/logging";
-import { Level } from "../../../../util/logging";
 import type { Computable } from "../../../command";
 import { Command } from "../../../command";
 
@@ -30,7 +29,7 @@ export class AttachFilesCommand extends Command<Attachment[], Parameters> {
             return [];
         }
         this.logger.message(
-            Level.INFO,
+            "info",
             `Attaching files to test execution issue ${resolvedExecutionIssueKey}`
         );
         return await this.parameters.jiraClient.addAttachment(resolvedExecutionIssueKey, ...files);

--- a/src/hooks/util/commands/jira/edit-issue-field-command.spec.ts
+++ b/src/hooks/util/commands/jira/edit-issue-field-command.spec.ts
@@ -8,7 +8,7 @@ import { AxiosRestClient } from "../../../../client/https/requests";
 import type { JiraClient } from "../../../../client/jira/jira-client";
 import { BaseJiraClient } from "../../../../client/jira/jira-client";
 import { dedent } from "../../../../util/dedent";
-import { Level, LOG } from "../../../../util/logging";
+import { LOG } from "../../../../util/logging";
 import { ConstantCommand } from "../constant-command";
 import { EditIssueFieldCommand } from "./edit-issue-field-command";
 
@@ -101,7 +101,7 @@ describe(relative(cwd(), __filename), async () => {
             );
             assert.deepStrictEqual(await command.compute(), ["CYP-123"]);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     CYP-456
 

--- a/src/hooks/util/commands/jira/edit-issue-field-command.ts
+++ b/src/hooks/util/commands/jira/edit-issue-field-command.ts
@@ -2,7 +2,6 @@ import type { JiraClient } from "../../../../client/jira/jira-client";
 import type { StringMap } from "../../../../types/util";
 import { dedent } from "../../../../util/dedent";
 import type { Logger } from "../../../../util/logging";
-import { Level } from "../../../../util/logging";
 import { unknownToString } from "../../../../util/string";
 import type { Computable } from "../../../command";
 import { Command } from "../../../command";
@@ -40,7 +39,7 @@ export class EditIssueFieldCommand<FieldValue> extends Command<string[], Paramet
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
             } catch (error: unknown) {
                 this.logger.message(
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         ${issueKey}
 

--- a/src/hooks/util/commands/jira/get-field-values-command.ts
+++ b/src/hooks/util/commands/jira/get-field-values-command.ts
@@ -4,7 +4,6 @@ import type { StringMap } from "../../../../types/util";
 import { dedent } from "../../../../util/dedent";
 import { errorMessage } from "../../../../util/errors";
 import type { Logger } from "../../../../util/logging";
-import { Level } from "../../../../util/logging";
 import type { Computable } from "../../../command";
 import { Command } from "../../../command";
 
@@ -42,7 +41,7 @@ export abstract class GetFieldValuesCommand<FieldValue> extends Command<
         if (unknownIssues.length > 0) {
             unknownIssues.sort();
             this.logger.message(
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Failed to find Jira issues:
 
@@ -66,7 +65,7 @@ export abstract class GetFieldValuesCommand<FieldValue> extends Command<
         if (issuesWithUnparseableField.length > 0) {
             issuesWithUnparseableField.sort();
             this.logger.message(
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Failed to parse Jira field with ID ${fieldId} in issues:
 

--- a/src/hooks/util/commands/jira/get-label-values-command.spec.ts
+++ b/src/hooks/util/commands/jira/get-label-values-command.spec.ts
@@ -8,7 +8,7 @@ import { AxiosRestClient } from "../../../../client/https/requests";
 import type { JiraClient } from "../../../../client/jira/jira-client";
 import { BaseJiraClient } from "../../../../client/jira/jira-client";
 import { dedent } from "../../../../util/dedent";
-import { Level, LOG } from "../../../../util/logging";
+import { LOG } from "../../../../util/logging";
 import { ConstantCommand } from "../constant-command";
 import { GetLabelValuesCommand } from "./get-label-values-command";
 
@@ -84,7 +84,7 @@ describe(relative(cwd(), __filename), async () => {
                 ["CYP-123"]: ["label"],
             });
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Failed to find Jira issues:
 
@@ -127,7 +127,7 @@ describe(relative(cwd(), __filename), async () => {
             );
             assert.deepStrictEqual(await command.compute(), {});
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Failed to parse Jira field with ID labels in issues:
 

--- a/src/hooks/util/commands/jira/get-summary-values-command.spec.ts
+++ b/src/hooks/util/commands/jira/get-summary-values-command.spec.ts
@@ -8,7 +8,7 @@ import { AxiosRestClient } from "../../../../client/https/requests";
 import type { JiraClient } from "../../../../client/jira/jira-client";
 import { BaseJiraClient } from "../../../../client/jira/jira-client";
 import { dedent } from "../../../../util/dedent";
-import { Level, LOG } from "../../../../util/logging";
+import { LOG } from "../../../../util/logging";
 import { ConstantCommand } from "../constant-command";
 import { GetSummaryValuesCommand } from "./get-summary-values-command";
 
@@ -84,7 +84,7 @@ describe(relative(cwd(), __filename), async () => {
                 ["CYP-123"]: "Hello",
             });
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Failed to find Jira issues:
 
@@ -130,7 +130,7 @@ describe(relative(cwd(), __filename), async () => {
             );
             assert.deepStrictEqual(await command.compute(), {});
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     Failed to parse Jira field with ID summary in issues:
 

--- a/src/hooks/util/commands/jira/transition-issue-command.spec.ts
+++ b/src/hooks/util/commands/jira/transition-issue-command.spec.ts
@@ -7,7 +7,7 @@ import { PatCredentials } from "../../../../client/authentication/credentials";
 import { AxiosRestClient } from "../../../../client/https/requests";
 import type { JiraClient } from "../../../../client/jira/jira-client";
 import { BaseJiraClient } from "../../../../client/jira/jira-client";
-import { LOG, Level } from "../../../../util/logging";
+import { LOG } from "../../../../util/logging";
 import { ConstantCommand } from "../constant-command";
 import { TransitionIssueCommand } from "./transition-issue-command";
 
@@ -32,7 +32,7 @@ describe(relative(cwd(), __filename), async () => {
             );
             await command.compute();
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Transitioning test execution issue CYP-123",
             ]);
             assert.deepStrictEqual(transitionIssue.mock.calls[0].arguments, [

--- a/src/hooks/util/commands/jira/transition-issue-command.ts
+++ b/src/hooks/util/commands/jira/transition-issue-command.ts
@@ -1,7 +1,6 @@
 import type { JiraClient } from "../../../../client/jira/jira-client";
 import type { IssueTransition } from "../../../../types/jira/responses/issue-transition";
 import type { Logger } from "../../../../util/logging";
-import { Level } from "../../../../util/logging";
 import type { Computable } from "../../../command";
 import { Command } from "../../../command";
 
@@ -24,7 +23,7 @@ export class TransitionIssueCommand extends Command<void, Parameters> {
     protected async computeResult(): Promise<void> {
         const resolvedExecutionIssueKey = await this.resolvedExecutionIssueKey.compute();
         this.logger.message(
-            Level.INFO,
+            "info",
             `Transitioning test execution issue ${resolvedExecutionIssueKey}`
         );
         await this.parameters.jiraClient.transitionIssue(resolvedExecutionIssueKey, {

--- a/src/hooks/util/commands/xray/import-feature-command.spec.ts
+++ b/src/hooks/util/commands/xray/import-feature-command.spec.ts
@@ -8,7 +8,7 @@ import { AxiosRestClient } from "../../../../client/https/requests";
 import type { XrayClient } from "../../../../client/xray/xray-client";
 import { ServerClient } from "../../../../client/xray/xray-client-server";
 import { dedent } from "../../../../util/dedent";
-import { Level, LOG } from "../../../../util/logging";
+import { LOG } from "../../../../util/logging";
 import { ImportFeatureCommand } from "./import-feature-command";
 
 describe(relative(cwd(), __filename), async () => {
@@ -42,7 +42,7 @@ describe(relative(cwd(), __filename), async () => {
                 updatedOrCreatedIssues: ["CYP-123", "CYP-42"],
             });
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Importing feature file to Xray: /path/to/some/cucumber.feature",
             ]);
         });
@@ -73,7 +73,7 @@ describe(relative(cwd(), __filename), async () => {
             );
             await command.compute();
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     /path/to/some/cucumber.feature
 

--- a/src/hooks/util/commands/xray/import-feature-command.ts
+++ b/src/hooks/util/commands/xray/import-feature-command.ts
@@ -1,7 +1,6 @@
 import type { XrayClient } from "../../../../client/xray/xray-client";
 import type { ImportFeatureResponse } from "../../../../types/xray/responses/import-feature";
 import { dedent } from "../../../../util/dedent";
-import { Level } from "../../../../util/logging";
 import { Command } from "../../../command";
 
 interface Parameters {
@@ -14,10 +13,7 @@ interface Parameters {
 
 export class ImportFeatureCommand extends Command<ImportFeatureResponse, Parameters> {
     protected async computeResult(): Promise<ImportFeatureResponse> {
-        this.logger.message(
-            Level.INFO,
-            `Importing feature file to Xray: ${this.parameters.filePath}`
-        );
+        this.logger.message("info", `Importing feature file to Xray: ${this.parameters.filePath}`);
         const importResponse = await this.parameters.xrayClient.importFeature(
             this.parameters.filePath,
             {
@@ -28,7 +24,7 @@ export class ImportFeatureCommand extends Command<ImportFeatureResponse, Paramet
         );
         if (importResponse.errors.length > 0) {
             this.logger.message(
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ${this.parameters.filePath}
 

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -194,6 +194,7 @@ describe(relative(cwd(), __filename), async () => {
                 {
                     ...options.plugin,
                     logDirectory: resolve(config.projectRoot, "xyz"),
+                    logger: undefined,
                 }
             );
             assert.deepStrictEqual(setGlobalContext.mock.calls[0].arguments[0].getOptions().xray, {
@@ -309,6 +310,7 @@ describe(relative(cwd(), __filename), async () => {
                 {
                     debug: pluginContext.getOptions().plugin.debug,
                     logDirectory: resolve(config.projectRoot, "logs"),
+                    logger: undefined,
                 },
             ]);
         });
@@ -330,6 +332,7 @@ describe(relative(cwd(), __filename), async () => {
                 {
                     debug: pluginContext.getOptions().plugin.debug,
                     logDirectory: resolve(config.projectRoot, "log-directory"),
+                    logger: undefined,
                 },
             ]);
         });
@@ -351,6 +354,32 @@ describe(relative(cwd(), __filename), async () => {
                 {
                     debug: pluginContext.getOptions().plugin.debug,
                     logDirectory: resolve("."),
+                    logger: undefined,
+                },
+            ]);
+        });
+
+        await it("initializes the logging module with custom loggers", async (context) => {
+            const configure = context.mock.method(LOG, "configure", context.mock.fn());
+            context.mock.method(globalContext, "initClients", () => pluginContext.getClients());
+            const logger = () => {
+                console.log("hello");
+            };
+            const options: CypressXrayPluginOptions = {
+                jira: {
+                    projectKey: "ABC",
+                    url: "http://localhost:1234",
+                },
+                plugin: {
+                    logger,
+                },
+            };
+            await configureXrayPlugin(mockedCypressEventEmitter, config, options);
+            assert.deepStrictEqual(configure.mock.calls[0].arguments, [
+                {
+                    debug: pluginContext.getOptions().plugin.debug,
+                    logDirectory: resolve(config.projectRoot, "logs"),
+                    logger: logger,
                 },
             ]);
         });

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -17,7 +17,7 @@ import type { CypressFailedRunResultType, CypressRunResultType } from "./types/c
 import type { CypressXrayPluginOptions } from "./types/plugin";
 import { dedent } from "./util/dedent";
 import { ExecutableGraph } from "./util/graph/executable-graph";
-import { CapturingLogger, Level, LOG } from "./util/logging";
+import { CapturingLogger, LOG } from "./util/logging";
 
 describe(relative(cwd(), __filename), async () => {
     let jiraClient: JiraClient;
@@ -80,7 +80,7 @@ describe(relative(cwd(), __filename), async () => {
                 },
             });
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Plugin disabled. Skipping further configuration.",
             ]);
             assert.strictEqual(mockedOn.mock.callCount(), 1);
@@ -98,7 +98,7 @@ describe(relative(cwd(), __filename), async () => {
                 },
             });
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Interactive mode detected, disabling plugin.",
             ]);
             assert.strictEqual(mockedOn.mock.callCount(), 1);
@@ -429,7 +429,7 @@ describe(relative(cwd(), __filename), async () => {
                 pluginContext.getOptions()
             );
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.ERROR,
+                "error",
                 dedent(`
                     Skipping results upload: Failed to run 47 tests.
 
@@ -445,7 +445,7 @@ describe(relative(cwd(), __filename), async () => {
                 plugin: { enabled: false },
             });
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Plugin disabled. Skipping further configuration.",
             ]);
         });
@@ -464,7 +464,7 @@ describe(relative(cwd(), __filename), async () => {
                 pluginContext.getOptions()
             );
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Plugin disabled. Skipping further configuration.",
             ]);
         });
@@ -484,7 +484,7 @@ describe(relative(cwd(), __filename), async () => {
                 pluginContext.getOptions()
             );
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Skipping results upload: Plugin is configured to not upload test results.",
             ]);
         });
@@ -509,11 +509,11 @@ describe(relative(cwd(), __filename), async () => {
                 }, 10);
             });
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 "Encountered problems during plugin execution!",
             ]);
             assert.deepStrictEqual(message.mock.calls[1].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ~/repositories/xray/cypress/e2e/demo/example.cy.ts
 
@@ -536,7 +536,7 @@ describe(relative(cwd(), __filename), async () => {
                 `),
             ]);
             assert.deepStrictEqual(message.mock.calls[2].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ~/repositories/xray/cypress/e2e/demo/example.cy.ts
 
@@ -559,7 +559,7 @@ describe(relative(cwd(), __filename), async () => {
                 `),
             ]);
             assert.deepStrictEqual(message.mock.calls[3].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ~/repositories/xray/cypress/e2e/demo/example.cy.ts
 
@@ -582,11 +582,11 @@ describe(relative(cwd(), __filename), async () => {
                 `),
             ]);
             assert.deepStrictEqual(message.mock.calls[4].arguments, [
-                Level.WARNING,
+                "warning",
                 "No test results were uploaded",
             ]);
             assert.deepStrictEqual(message.mock.calls[5].arguments, [
-                Level.ERROR,
+                "error",
                 dedent(`
                     Failed to upload Cypress execution results.
 
@@ -685,19 +685,19 @@ describe(relative(cwd(), __filename), async () => {
         assert.strictEqual(eventName, "after:run");
         await callback(afterRunResult);
         assert.deepStrictEqual(message.mock.calls[0].arguments, [
-            Level.INFO,
+            "info",
             "Parsing feature file: ./test/resources/features/invalid.feature",
         ]);
         assert.deepStrictEqual(message.mock.calls[1].arguments, [
-            Level.SUCCESS,
+            "notice",
             "Uploaded Cypress test results to issue: CYP-123 (http://localhost:1234/browse/CYP-123)",
         ]);
         assert.deepStrictEqual(message.mock.calls[2].arguments, [
-            Level.WARNING,
+            "warning",
             "Encountered problems during plugin execution!",
         ]);
         assert.deepStrictEqual(message.mock.calls[3].arguments, [
-            Level.ERROR,
+            "error",
             dedent(`
                 Failed to upload Cucumber execution results.
 
@@ -705,7 +705,7 @@ describe(relative(cwd(), __filename), async () => {
             `),
         ]);
         assert.deepStrictEqual(message.mock.calls[4].arguments, [
-            Level.ERROR,
+            "error",
             dedent(`
                 ./test/resources/features/invalid.feature
 
@@ -736,7 +736,7 @@ describe(relative(cwd(), __filename), async () => {
             const message = context.mock.method(LOG, "message", context.mock.fn());
             syncFeatureFile(file);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ./test/resources/features/taggedCloud.feature
 
@@ -755,7 +755,7 @@ describe(relative(cwd(), __filename), async () => {
             });
             syncFeatureFile(file);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 "Plugin disabled. Skipping further configuration.",
             ]);
         });
@@ -767,7 +767,7 @@ describe(relative(cwd(), __filename), async () => {
             globalContext.setGlobalContext(pluginContext);
             syncFeatureFile(file);
             assert.deepStrictEqual(message.mock.calls[0].arguments, [
-                Level.INFO,
+                "info",
                 dedent(`
                     ./test/resources/features/taggedCloud.feature
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -77,6 +77,7 @@ export async function configureXrayPlugin(
     LOG.configure({
         debug: pluginOptions.debug,
         logDirectory: pluginOptions.logDirectory,
+        logger: pluginOptions.logger,
     });
     const internalOptions: InternalCypressXrayPluginOptions = {
         cucumber: await globalContext.initCucumberOptions(config, options.cucumber),

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,7 +14,7 @@ import { dedent } from "./util/dedent";
 import { ExecutableGraph } from "./util/graph/executable-graph";
 import { ChainingCommandGraphLogger } from "./util/graph/logging/graph-logger";
 import { HELP } from "./util/help";
-import { CapturingLogger, LOG, Level } from "./util/logging";
+import { CapturingLogger, LOG } from "./util/logging";
 
 let canShowInitializationWarning = true;
 
@@ -53,7 +53,7 @@ export async function configureXrayPlugin(
         options.plugin
     );
     if (!pluginOptions.enabled) {
-        LOG.message(Level.INFO, "Plugin disabled. Skipping further configuration.");
+        LOG.message("info", "Plugin disabled. Skipping further configuration.");
         // Tasks must always be registered in case users forget to comment out imported commands.
         registerDefaultTasks(on);
         return;
@@ -62,7 +62,7 @@ export async function configureXrayPlugin(
     // See: https://github.com/cypress-io/cypress/issues/20789
     if (!config.isTextTerminal) {
         pluginOptions.enabled = false;
-        LOG.message(Level.INFO, "Interactive mode detected, disabling plugin.");
+        LOG.message("info", "Interactive mode detected, disabling plugin.");
         // Tasks must always be registered in case users forget to comment out imported commands.
         registerDefaultTasks(on);
         return;
@@ -120,7 +120,7 @@ export async function configureXrayPlugin(
             if ("status" in results && results.status === "failed") {
                 const failedResult = results;
                 LOG.message(
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         Skipping results upload: Failed to run ${failedResult.failures.toString()} tests.
 
@@ -140,7 +140,7 @@ export async function configureXrayPlugin(
             }
         } else {
             LOG.message(
-                Level.INFO,
+                "info",
                 "Skipping results upload: Plugin is configured to not upload test results."
             );
         }
@@ -150,19 +150,19 @@ export async function configureXrayPlugin(
             new ChainingCommandGraphLogger(logger).logGraph(context.getGraph());
             const messages = logger.getMessages();
             messages.forEach(([level, text]) => {
-                if ([Level.DEBUG, Level.INFO, Level.SUCCESS].includes(level)) {
+                if (["debug", "info", "notice"].includes(level)) {
                     LOG.message(level, text);
                 }
             });
-            if (messages.some(([level]) => level === Level.WARNING || level === Level.ERROR)) {
-                LOG.message(Level.WARNING, "Encountered problems during plugin execution!");
+            if (messages.some(([level]) => level === "warning" || level === "error")) {
+                LOG.message("warning", "Encountered problems during plugin execution!");
                 messages
-                    .filter(([level]) => level === Level.WARNING)
+                    .filter(([level]) => level === "warning")
                     .forEach(([level, text]) => {
                         LOG.message(level, text);
                     });
                 messages
-                    .filter(([level]) => level === Level.ERROR)
+                    .filter(([level]) => level === "error")
                     .forEach(([level, text]) => {
                         LOG.message(level, text);
                     });
@@ -190,7 +190,7 @@ export function syncFeatureFile(file: Cypress.FileObject): string {
     if (!context) {
         if (canShowInitializationWarning) {
             LOG.message(
-                Level.WARNING,
+                "warning",
                 dedent(`
                     ${file.filePath}
 
@@ -204,7 +204,7 @@ export function syncFeatureFile(file: Cypress.FileObject): string {
     }
     if (!context.getOptions().plugin.enabled) {
         LOG.message(
-            Level.INFO,
+            "info",
             dedent(`
                 ${file.filePath}
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -3,6 +3,7 @@ import type { AxiosRequestConfig } from "axios";
 import type { AxiosRestClient, RequestsOptions } from "../client/https/requests";
 import type { JiraClient } from "../client/jira/jira-client";
 import type { XrayClient } from "../client/xray/xray-client";
+import type { Level } from "../util/logging";
 import type { IssueUpdate } from "./jira/responses/issue-update";
 
 /**
@@ -709,6 +710,45 @@ export interface PluginOptions {
      * The directory which all error and debug log files will be written to.
      */
     logDirectory?: string;
+    /**
+     * A custom logger function that replaces the default ANSI-based logger for the plugin. If
+     * specified, this logger will completely replace the default plugin logger.
+     *
+     * Messages passed to this function:
+     * - will not contain the prefix `| Cypress Xray Plugin |`
+     * - will not contain ANSI escape characters
+     * - may contain line break characters
+     *
+     * @example
+     *
+     * ```ts
+     * (level: Level, ...text: string[]) => {
+     *   switch (level) {
+     *     case "debug":
+     *       if (process.env.DEBUG) {
+     *         console.debug(...text);
+     *       }
+     *       break;
+     *     case "error":
+     *       console.error("oh no", ...text);
+     *       break;
+     *     case "info":
+     *       console.info("fyi", ...text);
+     *       break;
+     *     case "notice":
+     *       console.log("please beware", ...text);
+     *       break;
+     *     case "warning":
+     *       console.warn("danger", ...text);
+     *       break;
+     *   }
+     * }
+     * ```
+     *
+     * @param level - the severity level of the log message
+     * @param text - one or more messages to be logged
+     */
+    logger?: (level: Level, ...text: string[]) => void;
     /**
      * Some Xray setups may have problems with uploaded evidence if the filenames contain non-ASCII
      * characters. With this option enabled, the plugin will only allow the characters `a-zA-Z0-9.`

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -715,7 +715,7 @@ export interface PluginOptions {
      * specified, this logger will completely replace the default plugin logger.
      *
      * Messages passed to this function:
-     * - will not contain the prefix `| Cypress Xray Plugin |`
+     * - will not contain the prefix `│ Cypress Xray Plugin │`
      * - will not contain ANSI escape characters
      * - may contain line break characters
      *

--- a/src/util/dependencies.ts
+++ b/src/util/dependencies.ts
@@ -2,7 +2,7 @@ import type {
     IPreprocessorConfiguration,
     resolvePreprocessorConfiguration,
 } from "@badeball/cypress-cucumber-preprocessor";
-import { LOG, Level } from "./logging";
+import { LOG } from "./logging";
 
 export type CucumberPreprocessorArgs = Parameters<typeof resolvePreprocessorConfiguration>;
 
@@ -22,7 +22,7 @@ export interface CucumberPreprocessorExports {
  */
 async function importOptionalDependency<T>(packageName: string): Promise<T> {
     const dependency: T = await EXPORTS._import(packageName);
-    LOG.message(Level.DEBUG, `Successfully imported optional dependency: ${packageName}`);
+    LOG.message("debug", `Successfully imported optional dependency: ${packageName}`);
     return dependency;
 }
 

--- a/src/util/graph/logging/graph-logger.spec.ts
+++ b/src/util/graph/logging/graph-logger.spec.ts
@@ -16,7 +16,7 @@ import type { CucumberMultipart } from "../../../types/xray/requests/import-exec
 import type { MultipartInfo } from "../../../types/xray/requests/import-execution-multipart-info";
 import { dedent } from "../../dedent";
 import { SkippedError } from "../../errors";
-import { CapturingLogger, Level } from "../../logging";
+import { CapturingLogger } from "../../logging";
 import { SimpleDirectedGraph } from "../graph";
 import { ChainingCommandGraphLogger, ChainingGraphLogger } from "./graph-logger";
 
@@ -49,7 +49,7 @@ describe(relative(cwd(), __filename), async () => {
             new ChainingGraphLogger(logger).logGraph(graph);
             assert.deepStrictEqual(logger.getMessages(), [
                 [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         F failed
 
@@ -59,7 +59,7 @@ describe(relative(cwd(), __filename), async () => {
                     `),
                 ],
                 [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         Z skipped
 
@@ -94,7 +94,7 @@ describe(relative(cwd(), __filename), async () => {
             new ChainingGraphLogger(logger).logGraph(graph);
             assert.deepStrictEqual(logger.getMessages(), [
                 [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         H skipped
 
@@ -110,7 +110,7 @@ describe(relative(cwd(), __filename), async () => {
                     `),
                 ],
                 [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         I skipped
 
@@ -191,7 +191,7 @@ describe(relative(cwd(), __filename), async () => {
             new ChainingGraphLogger(logger).logGraph(graph);
             assert.deepStrictEqual(logger.getMessages(), [
                 [
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         F skipped
 
@@ -226,19 +226,19 @@ describe(relative(cwd(), __filename), async () => {
             );
             assert.deepStrictEqual(logger.getMessages(), [
                 [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         E failed
                     `),
                 ],
                 [
-                    Level.WARNING,
+                    "warning",
                     dedent(`
                         F skipped
                     `),
                 ],
                 [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         B skipped
 
@@ -281,7 +281,7 @@ describe(relative(cwd(), __filename), async () => {
             new ChainingCommandGraphLogger(logger).logGraph(graph);
             assert.deepStrictEqual(logger.getMessages(), [
                 [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         Failed to upload Cucumber execution results.
 
@@ -319,7 +319,7 @@ describe(relative(cwd(), __filename), async () => {
             new ChainingCommandGraphLogger(logger).logGraph(graph);
             assert.deepStrictEqual(logger.getMessages(), [
                 [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         Failed to upload Cypress execution results.
 
@@ -356,7 +356,7 @@ describe(relative(cwd(), __filename), async () => {
             new ChainingCommandGraphLogger(logger).logGraph(graph);
             assert.deepStrictEqual(logger.getMessages(), [
                 [
-                    Level.ERROR,
+                    "error",
                     dedent(`
                         /path/to/file.feature
 

--- a/src/util/graph/logging/graph-logger.ts
+++ b/src/util/graph/logging/graph-logger.ts
@@ -6,14 +6,13 @@ import { ImportFeatureCommand } from "../../../hooks/util/commands/xray/import-f
 import { dedent } from "../../dedent";
 import { isSkippedError } from "../../errors";
 import type { Logger } from "../../logging";
-import { Level } from "../../logging";
 import { Queue } from "../../queue/queue";
 import { traverse } from "../algorithms/sort";
 import type { DirectedGraph } from "../graph";
 
 interface IndentedLogMessage<V extends Failable> {
     indent: number;
-    level: Level.ERROR | Level.WARNING;
+    level: "error" | "warning";
     text: string;
     vertex: V;
 }
@@ -62,7 +61,7 @@ export class ChainingGraphLogger<V extends Failable> {
         if (error) {
             return {
                 includePredecessors: false,
-                level: isSkippedError(error) ? Level.WARNING : Level.ERROR,
+                level: isSkippedError(error) ? "warning" : "error",
                 text: error.message,
             };
         }
@@ -132,8 +131,8 @@ export class ChainingGraphLogger<V extends Failable> {
         const level = chain
             .map((message) => message.level)
             .reduce((previous, current) => {
-                if (previous === Level.ERROR || current === Level.ERROR) {
-                    return Level.ERROR;
+                if (previous === "error" || current === "error") {
+                    return "error";
                 }
                 return previous;
             }, chain[0].level);
@@ -162,21 +161,21 @@ export class ChainingCommandGraphLogger extends ChainingGraphLogger<Command> {
             if (vertex instanceof ImportExecutionCypressCommand) {
                 return {
                     includePredecessors: true,
-                    level: Level.ERROR,
+                    level: "error",
                     text: "Failed to upload Cypress execution results.",
                 };
             }
             if (vertex instanceof ImportExecutionCucumberCommand) {
                 return {
                     includePredecessors: true,
-                    level: Level.ERROR,
+                    level: "error",
                     text: "Failed to upload Cucumber execution results.",
                 };
             }
             if (vertex instanceof ImportFeatureCommand) {
                 return {
                     includePredecessors: true,
-                    level: Level.ERROR,
+                    level: "error",
                     text: dedent(`
                         ${vertex.getParameters().filePath}
 

--- a/src/util/logging.spec.ts
+++ b/src/util/logging.spec.ts
@@ -8,7 +8,7 @@ import { cwd } from "node:process";
 import { describe, it } from "node:test";
 import { resolveTestDirPath } from "../../test/util";
 import { LoggedError } from "./errors";
-import { CapturingLogger, Level, PluginLogger } from "./logging";
+import { CapturingLogger, PluginLogger } from "./logging";
 
 describe(relative(cwd(), __filename), async () => {
     await describe(PluginLogger.name, async () => {
@@ -16,7 +16,7 @@ describe(relative(cwd(), __filename), async () => {
             await it("handles single line messages", (context) => {
                 const info = context.mock.method(console, "info", context.mock.fn());
                 const logger = new PluginLogger();
-                logger.message(Level.INFO, "hello");
+                logger.message("info", "hello");
                 assert.deepStrictEqual(info.mock.calls[0].arguments, [
                     `${ansiColors.white("│ Cypress Xray Plugin │ INFO    │")} ${ansiColors.gray(
                         "hello"
@@ -26,7 +26,7 @@ describe(relative(cwd(), __filename), async () => {
             await it("handles multi line messages", (context) => {
                 const info = context.mock.method(console, "info", context.mock.fn());
                 const logger = new PluginLogger();
-                logger.message(Level.INFO, "hello\nbonjour");
+                logger.message("info", "hello\nbonjour");
                 assert.deepStrictEqual(info.mock.callCount(), 3);
                 assert.deepStrictEqual(info.mock.calls[0].arguments, [
                     `${ansiColors.white("│ Cypress Xray Plugin │ INFO    │")} ${ansiColors.gray(
@@ -272,11 +272,11 @@ describe(relative(cwd(), __filename), async () => {
         await describe("message", async () => {
             await it("stores calls", () => {
                 const logger = new CapturingLogger();
-                logger.message(Level.INFO, "hello");
-                logger.message(Level.ERROR, "alarm");
+                logger.message("info", "hello");
+                logger.message("error", "alarm");
                 assert.deepStrictEqual(logger.getMessages(), [
-                    [Level.INFO, "hello"],
-                    [Level.ERROR, "alarm"],
+                    ["info", "hello"],
+                    ["error", "alarm"],
                 ]);
             });
         });

--- a/src/util/logging.spec.ts
+++ b/src/util/logging.spec.ts
@@ -42,6 +42,17 @@ describe(relative(cwd(), __filename), async () => {
                     ansiColors.white("│ Cypress Xray Plugin │ INFO    │"),
                 ]);
             });
+            await it("prefers custom loggers", (context) => {
+                const info = context.mock.method(console, "info", context.mock.fn());
+                const logger = new PluginLogger({
+                    logDirectory: ".",
+                    logger: (level, ...text) => {
+                        console.info("bonjour", level, ...text);
+                    },
+                });
+                logger.message("info", "hello");
+                assert.deepStrictEqual(info.mock.calls[0].arguments, ["bonjour", "info", "hello"]);
+            });
         });
 
         await describe("logToFile", async () => {

--- a/src/util/logging.ts
+++ b/src/util/logging.ts
@@ -4,13 +4,11 @@ import fs from "fs";
 import path from "path";
 import { isLoggedError } from "./errors";
 
-export enum Level {
-    DEBUG = "DEBUG",
-    ERROR = "ERROR",
-    INFO = "INFO",
-    SUCCESS = "SUCCESS",
-    WARNING = "WARNING",
-}
+const LOG_LEVELS = ["debug", "error", "info", "notice", "warning"] as const;
+/**
+ * The different log levels the plugin supports and uses.
+ */
+export type Level = (typeof LOG_LEVELS)[number];
 
 /**
  * A generic logging interface.
@@ -64,32 +62,32 @@ export class PluginLogger implements Logger {
 
     constructor(options: LoggingOptions = { logDirectory: "." }) {
         this.loggingOptions = options;
-        const maxPrefixLength = Math.max(...Object.values(Level).map((s) => s.length));
+        const maxPrefixLength = Math.max(...LOG_LEVELS.map((s) => s.length));
         this.prefixes = {
-            [Level.DEBUG]: this.prefix(Level.DEBUG, maxPrefixLength),
-            [Level.ERROR]: this.prefix(Level.ERROR, maxPrefixLength),
-            [Level.INFO]: this.prefix(Level.INFO, maxPrefixLength),
-            [Level.SUCCESS]: this.prefix(Level.SUCCESS, maxPrefixLength),
-            [Level.WARNING]: this.prefix(Level.WARNING, maxPrefixLength),
+            ["debug"]: this.prefix("debug", maxPrefixLength),
+            ["error"]: this.prefix("error", maxPrefixLength),
+            ["info"]: this.prefix("info", maxPrefixLength),
+            ["notice"]: this.prefix("notice", maxPrefixLength),
+            ["warning"]: this.prefix("warning", maxPrefixLength),
         };
         this.colorizers = {
-            [Level.DEBUG]: ansiColors.cyan,
-            [Level.ERROR]: ansiColors.red,
-            [Level.INFO]: ansiColors.gray,
-            [Level.SUCCESS]: ansiColors.green,
-            [Level.WARNING]: ansiColors.yellow,
+            ["debug"]: ansiColors.cyan,
+            ["error"]: ansiColors.red,
+            ["info"]: ansiColors.gray,
+            ["notice"]: ansiColors.green,
+            ["warning"]: ansiColors.yellow,
         };
         this.logFunctions = {
-            [Level.DEBUG]: console.debug,
-            [Level.ERROR]: console.error,
-            [Level.INFO]: console.info,
-            [Level.SUCCESS]: console.log,
-            [Level.WARNING]: console.warn,
+            ["debug"]: console.debug,
+            ["error"]: console.error,
+            ["info"]: console.info,
+            ["notice"]: console.log,
+            ["warning"]: console.warn,
         };
     }
 
     public message(level: Level, ...text: string[]) {
-        if (level === Level.DEBUG && !this.loggingOptions.debug) {
+        if (level === "debug" && !this.loggingOptions.debug) {
             return;
         }
         const colorizer = this.colorizers[level];
@@ -141,15 +139,17 @@ export class PluginLogger implements Logger {
             errorData = error;
         }
         const filepath = this.logToFile(JSON.stringify(errorData, null, 2), errorFileName);
-        this.message(Level.ERROR, `Complete error logs have been written to: ${filepath}`);
+        this.message("error", `Complete error logs have been written to: ${filepath}`);
     }
 
     public configure(options: LoggingOptions): void {
         this.loggingOptions = options;
     }
 
-    private prefix(type: string, maxPrefixLength: number): string {
-        return ansiColors.white(`│ Cypress Xray Plugin │ ${type.padEnd(maxPrefixLength, " ")} │`);
+    private prefix(level: string, maxPrefixLength: number): string {
+        return ansiColors.white(
+            `│ Cypress Xray Plugin │ ${level.toUpperCase().padEnd(maxPrefixLength, " ")} │`
+        );
     }
 }
 

--- a/src/util/logging.ts
+++ b/src/util/logging.ts
@@ -41,6 +41,7 @@ export interface Logger {
     /**
      * Logs a log message.
      *
+     * @param level - the log level
      * @param text - the individual messages
      */
     message(level: Level, ...text: string[]): void;
@@ -49,6 +50,7 @@ export interface Logger {
 interface LoggingOptions {
     debug?: boolean;
     logDirectory: string;
+    logger?: (level: Level, ...text: string[]) => void;
 }
 
 /**
@@ -57,7 +59,7 @@ interface LoggingOptions {
 export class PluginLogger implements Logger {
     private readonly prefixes: Record<Level, string>;
     private readonly colorizers: Record<Level, ansiColors.StyleFunction>;
-    private readonly logFunctions: Record<Level, (...data: unknown[]) => void>;
+    private readonly logFunctions: Record<Level, (...data: string[]) => void>;
     private loggingOptions: LoggingOptions;
 
     constructor(options: LoggingOptions = { logDirectory: "." }) {
@@ -87,6 +89,11 @@ export class PluginLogger implements Logger {
     }
 
     public message(level: Level, ...text: string[]) {
+        // Prefer custom logger to the default plugin one.
+        if (this.loggingOptions.logger) {
+            this.loggingOptions.logger(level, ...text);
+            return;
+        }
         if (level === "debug" && !this.loggingOptions.debug) {
             return;
         }


### PR DESCRIPTION
The new `plugin.logger` option can be used to replace the plugin's default logging behaviour with a custom one:

```ts
{
  plugin: {
    logger: (level: Level, ...text: string[]) => {
      switch (level) {
        case "debug":
          if (process.env.DEBUG) {
            console.debug(...text);
          }
          break;
        case "error":
          console.error("oh no", ...text);
          break;
        case "info":
          console.info("fyi", ...text);
          break;
        case "notice":
          console.log("please beware", ...text);
          break;
        case "warning":
          console.warn("danger", ...text);
          break;
        }
      }
    }
  }
}
```

Outputs:
```console
fyi Jira username and API token found. Setting up Jira cloud basic auth credentials.
fyi Xray client ID and client secret found. Setting up Xray cloud JWT credentials.
fyi Authenticating to: https://xray.cloud.getxray.app/api/v2/authenticate...
...
```