### PR TITLE
Disable auto-publish workflow (npm auth not configured)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,15 @@
 name: Publish Package to npmjs
+# Disabled auto-publish on release events (2026-05-20): npm auth was not configured
+# after the September 2025 archival pause, causing the v9.0.0 release publish to fail
+# with 404/permission denied. Re-enable by restoring the `release: published` trigger
+# once npm Trusted Publishers (or NPM_TOKEN secret) is set up for Qytera-Gmbh/cypress-xray-plugin
+# under the qytera npmjs.com account.
 # see:
 # - https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
 # - https://docs.npmjs.com/trusted-publishers
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
   publish-npm:


### PR DESCRIPTION
## Summary

The v9.0.0 release publish failed with `E404 / permission denied` — npm Trusted Publishers is not registered for this repo under the `qytera` npmjs.com account after the September 2025 archival pause.

Switching `publish.yml` from `release: published` trigger to `workflow_dispatch` only, so:
- No more auto-publish attempts when a GitHub release is published
- Workflow can still be triggered manually once auth is configured

## Re-enable instructions

Once npm Trusted Publishers (or an `NPM_TOKEN` secret) is set up for `Qytera-Gmbh/cypress-xray-plugin`:

```yaml
on:
  release:
    types: [published]
```

## Linked issues

See follow-up backlog task in QYQ-Cockpit for the npm-publish setup.